### PR TITLE
feat: add Cursor and GitHub Copilot Instruction details + tool setup

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,82 @@
+# Copilot Instructions — Defra AI Tool Guidance Site
+
+## Project Overview
+
+This is a **Jekyll-based GitHub Pages site** providing AI tool guidance for Defra (UK Government) pilot teams. It documents approved AI tools and MCP servers with privacy, compliance, and data-handling assessments. The audience is government digital professionals evaluating AI tools for secure adoption.
+
+## Architecture
+
+- **Static site generator:** Jekyll with `jekyll-theme-minimal`, hosted on GitHub Pages
+- **Config:** `_config.yml` — sets `baseurl: '/ai-sdlc-tool-guidance'`, version numbers, and excluded paths
+- **Layout:** Single custom layout at `_layouts/default.html` with sidebar nav, dark/light theme toggle, and GOV.UK-styled branding
+- **Styles:** `_sass/defra-styles.scss` overrides the theme using GOV.UK and Defra colour variables (CSS custom properties with light/dark themes). Imported via `assets/css/style.scss`
+- **Content:** All guidance is pure Markdown in `tool-guidance/` (AI tools) and `tool-guidance/mcps/` (MCP servers)
+
+## Content Structure & Naming Conventions
+
+Every tool has exactly two files following this naming pattern:
+
+| Type | Pattern | Example |
+|------|---------|---------|
+| Summary | `tool-guidance/{tool-slug}-summary.md` | `github-copilot-summary.md` |
+| Detailed | `tool-guidance/{tool-slug}-detailed.md` | `github-copilot-detailed.md` |
+| MCP Summary | `tool-guidance/mcps/{tool-slug}-mcp-summary.md` | `github-mcp-summary.md` |
+| MCP Detailed | `tool-guidance/mcps/{tool-slug}-mcp-detailed.md` | `github-mcp-detailed.md` |
+
+### Required sections — Tool Summary files
+
+Summaries follow the template in `prompts/tool-summary-prompt.md`:
+`Tool Overview` → `Privacy Settings` → `Terms of Use and Privacy Policy` → `Data Management` (with sub-sections: Multi-Regional Processing, Data in Transit, Data at Rest) → `Auditing` → `Access Controls` → `Compliance & Regulatory Considerations` → `References`
+
+### Required sections — MCP Summary files
+
+MCP summaries add a `Key Risks & Threat Vectors` section (see `prompts/mcp-tool-summary-prompt.md`).
+
+### Required sections — Detailed files
+
+Detailed guides follow `prompts/deep-research-tool-guidance-prompt.md` with numbered sections (1–8) and sub-sections like `4.1 Server Location`, `4.2 Data in Transit`, `4.3 Data at Rest`, `4.4 Data Retention`.
+
+## Writing Style (Critical)
+
+Follow the rules in `.cursor/rules/playbook-general-rules.mdc`:
+
+- **British English** — "organisation" not "organization", "colour" not "color"
+- **GOV.UK style guide** and plain English — sentences under 25 words, active voice, address readers as "you"
+- **No hedging** — avoid "please", "simply", "just"
+- **Start instructions with verbs** — "Configure the API" not "The API should be configured"
+- **Define technical terms** on first use
+- Target audience: experienced government digital professionals new to GenAI in SDLC
+
+## Navigation & Linking
+
+When adding a new tool, update these locations:
+1. `README.md` — add bullet with Summary and Detailed links
+2. `_layouts/default.html` — add `<li>` entry in the sidebar `<nav>` section
+3. For MCP tools: also add to `restricted-mcp.md` using Liquid `relative_url` filter syntax: `{{ "/tool-guidance/mcps/{slug}" | relative_url }}`
+
+All internal links in Markdown rendered pages use Liquid's `relative_url` filter (e.g. `{{ "/tool-guidance/claude-summary" | relative_url }}`). In pure Markdown files like `README.md`, use relative paths (e.g. `tool-guidance/claude-summary.md`).
+
+## Local Development
+
+```bash
+./scripts/local-dev/setup.sh   # first-time Ruby/Bundler/gem install
+./scripts/local-dev/serve.sh   # dev server at http://localhost:4000/ai-sdlc-tool-guidance
+./scripts/local-dev/build.sh   # production build to _site/
+```
+
+## Key Files
+
+- `_config.yml` — site metadata, version, build exclusions
+- `_layouts/default.html` — the only layout; contains all nav links
+- `_sass/defra-styles.scss` — GOV.UK/Defra design tokens and component styles
+- `restricted-mcp.md` — landing page for restricted MCP server guidance
+- `prompts/` — prompt templates used to generate/validate guidance content (excluded from build)
+- `scripts/` — local dev and git helper scripts (excluded from build)
+- `.cursor/rules/playbook-general-rules.mdc` — voice/tone rules (always apply)
+
+## Things to Avoid
+
+- Do not add OFFICIAL-SENSITIVE or classified data — this is a public guidance site
+- Do not change `baseurl` in `_config.yml` without updating all nav links
+- Do not edit `prompts/` or `scripts/` expecting them to appear on the built site — they are excluded in `_config.yml`
+- Do not use American English spelling

--- a/Gemfile
+++ b/Gemfile
@@ -13,7 +13,7 @@ platforms :mingw, :x64_mingw, :mswin, :jruby do
 end
 
 # Performance-booster for watching directories on Windows
-gem "wdm", "~> 0.1.1", :platforms => [:mingw, :x64_mingw, :mswin]
+gem "wdm", ">= 0.1.0", :platforms => [:mingw, :x64_mingw, :mswin]
 
 # Lock `http_parser.rb` gem to `v0.6.x` on JRuby builds since newer versions of the gem
 # do not have a Java counterpart.

--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@ Version 1.3
 
 This document explains what AI tools you can use as part of the Defra AI pilot. It covers how data is used by these tools, what privacy settings are in place, what auditing and logging is in place, and what compliance and regulations they follow.
 
+> **Start here:** If you are new to using AI in software development, read the [Defra AI in the SDLC playbook](https://defra.github.io/defra-ai-sdlc/){:target="_blank"} (opens in new tab) first. It covers the [four pillars](https://defra.github.io/defra-ai-sdlc/pages/getting-started/the-four-pillars){:target="_blank"} (opens in new tab) of working effectively with AI, development workflows, testing approaches and prompt engineering. This site provides the tool-specific configuration and setup guidance that supports those practices.
+
 ## Who can use these AI tools
 
 These AI tools are allowed in the Defra pilot, but only if you follow these restrictions:
@@ -45,6 +47,19 @@ These tools are allowed in the Defra pilot when you follow the tool guidance adv
 MCP servers are restricted and currently under review. Only designated pilot projects can use MCP.
 
 Read the guidance: [Restricted: MCP]({{ "/restricted-mcp" | relative_url }})
+
+## Tool Setup
+
+Practical guides for configuring AI coding tools in Defra projects, with example agents, instructions, and reusable prompts that encode Defra software development standards.
+
+- **GitHub Copilot** - [Setup guide](tool-setup/github-copilot-setup.md)
+  - [Example agents](tool-setup/github-copilot/agents/index.md) (Defra App Developer, Code Reviewer, Tester)
+  - [Example instructions](tool-setup/github-copilot/instructions/index.md) (root config, Node.js backend, frontend)
+  - [Example prompts](tool-setup/github-copilot/prompts/index.md) (ADR, tests, security review)
+- **Cursor** - [Setup guide](tool-setup/cursor-setup.md)
+  - [Node.js backend rules](tool-setup/cursor/nodejs-backend-rules.md) (Hapi, MongoDB, REST API, Jest)
+  - [Node.js frontend rules](tool-setup/cursor/nodejs-frontend-rules.md) (GOV.UK, Nunjucks, Playwright)
+  - [Python backend rules](tool-setup/cursor/python-backend-rules.md) (FastAPI, pytest, MongoDB)
 
 ## Contact Us
 The Defra AI Capabilities and Enablement team maintains this playbook. Contact us:

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -1,217 +1,261 @@
 <!DOCTYPE html>
-<html lang="{{ site.lang | default: "en-GB" }}" data-theme="light">
-  <head>
-    <meta charset="UTF-8">
-    <meta http-equiv="X-UA-Compatible" content="IE=edge">
-    <meta name="viewport" content="width=device-width, initial-scale=1">
-    <link rel="icon" type="image/x-icon" href="{{ "/assets/images/favicon.ico" | relative_url }}">
+<html lang="{{ site.lang | default: " en-GB" }}" data-theme="light">
 
-{% seo %}
-    <link rel="stylesheet" href="{{ "/assets/css/style.css?v=" | append: site.css_version | relative_url }}">
-    <!--[if lt IE 9]>
+<head>
+  <meta charset="UTF-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <link rel="icon" type="image/x-icon" href="{{ " /assets/images/favicon.ico" | relative_url }}">
+
+  {% seo %}
+  <link rel="stylesheet" href="{{ " /assets/css/style.css?v=" | append: site.css_version | relative_url }}">
+  <!--[if lt IE 9]>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/html5shiv/3.7.3/html5shiv.min.js"></script>
     <![endif]-->
-    {% include head-custom.html %}
-    <style>
-      .content {
-        overflow-x: hidden;
-      }
-    </style>
-  </head>
-  <body>
-    <div class="wrapper">
-      <div class="navigation">
-        {% if site.logo %}
-        <div class="logo-container">
-          <a href="{{ "/" | relative_url }}">
-            <img class="logo-light" src="{{site.logo | relative_url}}" alt="Defra Logo" />
-            <img class="logo-dark" src="{{ "/assets/images/defra-logo-white.svg" | relative_url }}" alt="Defra Logo" />
-          </a>
+  {% include head-custom.html %}
+  <style>
+    .content {
+      overflow-x: hidden;
+    }
+  </style>
+</head>
+
+<body>
+  <div class="wrapper">
+    <div class="navigation">
+      {% if site.logo %}
+      <div class="logo-container">
+        <a href="{{ " /" | relative_url }}">
+          <img class="logo-light" src="{{site.logo | relative_url}}" alt="Defra Logo" />
+          <img class="logo-dark" src="{{ " /assets/images/defra-logo-white.svg" | relative_url }}" alt="Defra Logo" />
+        </a>
+      </div>
+      {% endif %}
+
+      <header>
+        <h1><a href="{{ " /" | absolute_url }}">{{ site.title | default: site.github.repository_name }}</a></h1>
+        <p>{{ site.description | default: site.github.project_tagline }}</p>
+      </header>
+
+      <!-- Theme Toggle -->
+      <label class="theme-toggle">
+        <input class="theme-toggle-checkbox" type="checkbox">
+        <div class="theme-toggle-switch" style="background: var(--govuk-dark-grey);">
+          <span class="toggle-icon light" style="display: flex; align-items: center;">
+            <svg class="sun-icon" xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24"
+              fill="none" stroke="white" stroke-width="2">
+              <circle cx="12" cy="12" r="5"></circle>
+              <line x1="12" y1="1" x2="12" y2="3"></line>
+              <line x1="12" y1="21" x2="12" y2="23"></line>
+              <line x1="4.22" y1="4.22" x2="5.64" y2="5.64"></line>
+              <line x1="18.36" y1="18.36" x2="19.78" y2="19.78"></line>
+              <line x1="1" y1="12" x2="3" y2="12"></line>
+              <line x1="21" y1="12" x2="23" y2="12"></line>
+              <line x1="4.22" y1="19.78" x2="5.64" y2="18.36"></line>
+              <line x1="18.36" y1="5.64" x2="19.78" y2="4.22"></line>
+            </svg>
+          </span>
+          <span class="toggle-icon dark" style="display: flex; align-items: center;">
+            <svg class="moon-icon" xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24"
+              fill="none" stroke="currentColor" stroke-width="2">
+              <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"></path>
+            </svg>
+          </span>
         </div>
-        {% endif %}
+      </label>
 
-        <header>
-          <h1><a href="{{ "/" | absolute_url }}">{{ site.title | default: site.github.repository_name }}</a></h1>
-          <p>{{ site.description | default: site.github.project_tagline }}</p>
-        </header>
+      <!-- Navigation Menu -->
+      <nav class="site-nav">
+        <h2>Navigation</h2>
+        <ul>
+          <li><a href="{{ " /" | relative_url }}">Home</a></li>
+          <li>
+            <a href="{{ " /" | relative_url }}">AI tools</a>
+            <ul>
+              <li><a href="{{ " /tool-guidance/amazon-q-developers-summary" | relative_url }}">Amazon Q for
+                  Developers</a></li>
+              <li><a href="{{ " /tool-guidance/aws-bedrock-summary" | relative_url }}">AWS Bedrock</a></li>
+              <li><a href="{{ " /tool-guidance/azure-ai-foundry-summary" | relative_url }}">Azure AI Foundry</a></li>
+              <li><a href="{{ " /tool-guidance/chat-gpt-summary" | relative_url }}">ChatGPT</a></li>
+              <li><a href="{{ " /tool-guidance/claude-summary" | relative_url }}">Claude</a></li>
+              <li><a href="{{ " /tool-guidance/claude-code-summary" | relative_url }}">Claude Code</a></li>
+              <li><a href="{{ " /tool-guidance/cursor-summary" | relative_url }}">Cursor</a></li>
+              <li><a href="{{ " /tool-guidance/github-copilot-summary" | relative_url }}">GitHub Copilot</a></li>
+              <li><a href="{{ " /tool-guidance/google-gemini-summary" | relative_url }}">Google Gemini</a></li>
+              <li><a href="{{ " /tool-guidance/notebooklm-summary" | relative_url }}">Google NotebookLM</a></li>
+              <li><a href="{{ " /tool-guidance/windsurf-summary" | relative_url }}">Windsurf</a></li>
+            </ul>
+          </li>
+          <li>
+            <a href="{{ " /restricted-mcp" | relative_url }}">Restricted: MCP</a>
+          </li>
+          <li>
+            <a href="{{ " /tool-setup" | relative_url }}">Tool Setup</a>
+            <ul>
+              <li>
+                <a href="{{ " /tool-setup/github-copilot-setup" | relative_url }}">GitHub Copilot</a>
+                <ul>
+                  <li><a href="{{ " /tool-setup/github-copilot/agents" | relative_url }}">Agents</a></li>
+                  <li><a href="{{ " /tool-setup/github-copilot/instructions" | relative_url }}">Instructions</a></li>
+                  <li><a href="{{ " /tool-setup/github-copilot/prompts" | relative_url }}">Prompts</a></li>
+                </ul>
+              </li>
+              <li>
+                <a href="{{ " /tool-setup/cursor-setup" | relative_url }}">Cursor</a>
+                <ul>
+                  <li><a href="{{ " /tool-setup/cursor/nodejs-backend-rules" | relative_url }}">Node.js backend</a></li>
+                  <li><a href="{{ " /tool-setup/cursor/nodejs-frontend-rules" | relative_url }}">Node.js frontend</a>
+                  </li>
+                  <li><a href="{{ " /tool-setup/cursor/python-backend-rules" | relative_url }}">Python backend</a></li>
+                </ul>
+              </li>
+              <li><a href="{{ " /tool-setup/cross-tool-config" | relative_url }}">Cross-tool config</a></li>
+            </ul>
+          </li>
+        </ul>
+      </nav>
 
-        <!-- Theme Toggle -->
-        <label class="theme-toggle">
-          <input class="theme-toggle-checkbox" type="checkbox">
-          <div class="theme-toggle-switch" style="background: var(--govuk-dark-grey);">
-            <span class="toggle-icon light" style="display: flex; align-items: center;">
-              <svg class="sun-icon" xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="white" stroke-width="2">
-                <circle cx="12" cy="12" r="5"></circle>
-                <line x1="12" y1="1" x2="12" y2="3"></line>
-                <line x1="12" y1="21" x2="12" y2="23"></line>
-                <line x1="4.22" y1="4.22" x2="5.64" y2="5.64"></line>
-                <line x1="18.36" y1="18.36" x2="19.78" y2="19.78"></line>
-                <line x1="1" y1="12" x2="3" y2="12"></line>
-                <line x1="21" y1="12" x2="23" y2="12"></line>
-                <line x1="4.22" y1="19.78" x2="5.64" y2="18.36"></line>
-                <line x1="18.36" y1="5.64" x2="19.78" y2="4.22"></line>
-              </svg>
-            </span>
-            <span class="toggle-icon dark" style="display: flex; align-items: center;">
-              <svg class="moon-icon" xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-                <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"></path>
-              </svg>
-            </span>
-          </div>
-        </label>
+      <footer>
+        <p>
+          {% if site.github.is_project_page %}
+          <small>View the Project on GitHub <a href="{{ site.github.repository_url }}">{{ site.github.repository_nwo
+              }}</a></small>
+          {% endif %}
+          {% if site.github.is_project_page %}
+          <br /><small>This project is maintained by <a href="{{ site.github.owner_url }}">{{ site.github.owner_name
+              }}</a></small>
+          {% endif %}
+          <br /><small>Hosted on GitHub Pages &mdash; Theme by <a
+              href="https://github.com/orderedlist">orderedlist</a></small>
+          <br /><small>Site Version {{ site.version }}</small>
+        </p>
+      </footer>
+    </div>
 
-        <!-- Navigation Menu -->
-        <nav class="site-nav">
-          <h2>Navigation</h2>
-          <ul>
-            <li><a href="{{ "/" | relative_url }}">Home</a></li>
-            <li>
-              <a href="{{ "/" | relative_url }}">AI tools</a>
-              <ul>
-                <li><a href="{{ "/tool-guidance/amazon-q-developers-summary" | relative_url }}">Amazon Q for Developers</a></li>
-                <li><a href="{{ "/tool-guidance/aws-bedrock-summary" | relative_url }}">AWS Bedrock</a></li>
-                <li><a href="{{ "/tool-guidance/azure-ai-foundry-summary" | relative_url }}">Azure AI Foundry</a></li>
-                <li><a href="{{ "/tool-guidance/chat-gpt-summary" | relative_url }}">ChatGPT</a></li>
-                <li><a href="{{ "/tool-guidance/claude-summary" | relative_url }}">Claude</a></li>
-                <li><a href="{{ "/tool-guidance/claude-code-summary" | relative_url }}">Claude Code</a></li>
-                <li><a href="{{ "/tool-guidance/cursor-summary" | relative_url }}">Cursor</a></li>
-                <li><a href="{{ "/tool-guidance/github-copilot-summary" | relative_url }}">GitHub Copilot</a></li>
-                <li><a href="{{ "/tool-guidance/google-gemini-summary" | relative_url }}">Google Gemini</a></li>
-                <li><a href="{{ "/tool-guidance/notebooklm-summary" | relative_url }}">Google NotebookLM</a></li>
-                <li><a href="{{ "/tool-guidance/windsurf-summary" | relative_url }}">Windsurf</a></li>
-              </ul>
+    <div class="content">
+      <section>
+        {{ content }}
+      </section>
+
+      <!-- Footer -->
+      <div class="govuk-footer__meta">
+        <div class="govuk-footer__meta-item govuk-footer__meta-item--grow">
+          <h2 class="govuk-visually-hidden">Support links</h2>
+          <ul class="govuk-footer__inline-list govuk-!-display-none-print">
+            <li class="govuk-footer__inline-list-item">
+              <a class="govuk-footer__link"
+                data-ga4-link="{&quot;event_name&quot;:&quot;navigation&quot;,&quot;type&quot;:&quot;footer&quot;,&quot;index_link&quot;:&quot;1&quot;,&quot;index_section&quot;:&quot;3&quot;,&quot;index_section_count&quot;:&quot;5&quot;,&quot;index_total&quot;:&quot;8&quot;,&quot;section&quot;:&quot;Support links&quot;}"
+                href="https://www.gov.uk/government/organisations/department-for-environment-food-rural-affairs">Department
+                for Environment, Food & Rural Affairs (Defra)</a>
             </li>
-            <li>
-              <a href="{{ "/restricted-mcp" | relative_url }}">Restricted: MCP</a>
+            <li class="govuk-footer__inline-list-item">
+              <a class="govuk-footer__link"
+                data-ga4-link="{&quot;event_name&quot;:&quot;navigation&quot;,&quot;type&quot;:&quot;footer&quot;,&quot;index_link&quot;:&quot;1&quot;,&quot;index_section&quot;:&quot;3&quot;,&quot;index_section_count&quot;:&quot;5&quot;,&quot;index_total&quot;:&quot;8&quot;,&quot;section&quot;:&quot;Support links&quot;}"
+                href="https://www.gov.uk/help">Help</a>
+            </li>
+            <li class="govuk-footer__inline-list-item">
+              <a class="govuk-footer__link"
+                data-ga4-link="{&quot;event_name&quot;:&quot;navigation&quot;,&quot;type&quot;:&quot;footer&quot;,&quot;index_link&quot;:&quot;2&quot;,&quot;index_section&quot;:&quot;3&quot;,&quot;index_section_count&quot;:&quot;5&quot;,&quot;index_total&quot;:&quot;8&quot;,&quot;section&quot;:&quot;Support links&quot;}"
+                href="https://www.gov.uk/help/privacy-notice">Privacy</a>
+            </li>
+            <li class="govuk-footer__inline-list-item">
+              <a class="govuk-footer__link"
+                data-ga4-link="{&quot;event_name&quot;:&quot;navigation&quot;,&quot;type&quot;:&quot;footer&quot;,&quot;index_link&quot;:&quot;3&quot;,&quot;index_section&quot;:&quot;3&quot;,&quot;index_section_count&quot;:&quot;5&quot;,&quot;index_total&quot;:&quot;8&quot;,&quot;section&quot;:&quot;Support links&quot;}"
+                href="https://www.gov.uk/help/cookies">Cookies</a>
+            </li>
+            <li class="govuk-footer__inline-list-item">
+              <a class="govuk-footer__link"
+                data-ga4-link="{&quot;event_name&quot;:&quot;navigation&quot;,&quot;type&quot;:&quot;footer&quot;,&quot;index_link&quot;:&quot;4&quot;,&quot;index_section&quot;:&quot;3&quot;,&quot;index_section_count&quot;:&quot;5&quot;,&quot;index_total&quot;:&quot;8&quot;,&quot;section&quot;:&quot;Support links&quot;}"
+                href="https://www.gov.uk/help/accessibility-statement">Accessibility statement</a>
+            </li>
+            <li class="govuk-footer__inline-list-item">
+              <a class="govuk-footer__link"
+                data-ga4-link="{&quot;event_name&quot;:&quot;navigation&quot;,&quot;type&quot;:&quot;footer&quot;,&quot;index_link&quot;:&quot;5&quot;,&quot;index_section&quot;:&quot;3&quot;,&quot;index_section_count&quot;:&quot;5&quot;,&quot;index_total&quot;:&quot;8&quot;,&quot;section&quot;:&quot;Support links&quot;}"
+                href="https://www.gov.uk/contact">Contact</a>
+            </li>
+            <li class="govuk-footer__inline-list-item">
+              <a class="govuk-footer__link"
+                data-ga4-link="{&quot;event_name&quot;:&quot;navigation&quot;,&quot;type&quot;:&quot;footer&quot;,&quot;index_link&quot;:&quot;6&quot;,&quot;index_section&quot;:&quot;3&quot;,&quot;index_section_count&quot;:&quot;5&quot;,&quot;index_total&quot;:&quot;8&quot;,&quot;section&quot;:&quot;Support links&quot;}"
+                href="https://www.gov.uk/help/terms-conditions">Terms and conditions</a>
+            </li>
+            <li class="govuk-footer__inline-list-item">
+              <a class="govuk-footer__link" lang="cy"
+                data-ga4-link="{&quot;event_name&quot;:&quot;navigation&quot;,&quot;type&quot;:&quot;footer&quot;,&quot;index_link&quot;:&quot;7&quot;,&quot;index_section&quot;:&quot;3&quot;,&quot;index_section_count&quot;:&quot;5&quot;,&quot;index_total&quot;:&quot;8&quot;,&quot;section&quot;:&quot;Support links&quot;}"
+                href="https://www.gov.uk/cymraeg">Rhestr o Wasanaethau Cymraeg</a>
+            </li>
+            <li class="govuk-footer__inline-list-item">
+              <a class="govuk-footer__link"
+                data-ga4-link="{&quot;event_name&quot;:&quot;navigation&quot;,&quot;type&quot;:&quot;footer&quot;,&quot;index_link&quot;:&quot;8&quot;,&quot;index_section&quot;:&quot;3&quot;,&quot;index_section_count&quot;:&quot;5&quot;,&quot;index_total&quot;:&quot;8&quot;,&quot;section&quot;:&quot;Support links&quot;}"
+                href="https://www.gov.uk/government/organisations/government-digital-service">Government Digital
+                Service</a>
             </li>
           </ul>
-        </nav>
-
-        <footer>
-          <p>
-            {% if site.github.is_project_page %}
-            <small>View the Project on GitHub <a href="{{ site.github.repository_url }}">{{ site.github.repository_nwo }}</a></small>
-            {% endif %}
-            {% if site.github.is_project_page %}
-            <br /><small>This project is maintained by <a href="{{ site.github.owner_url }}">{{ site.github.owner_name }}</a></small>
-            {% endif %}
-            <br /><small>Hosted on GitHub Pages &mdash; Theme by <a href="https://github.com/orderedlist">orderedlist</a></small>
-            <br /><small>Site Version {{ site.version }}</small>
-          </p>
-        </footer>
-      </div>
-
-      <div class="content">
-        <section>
-          {{ content }}
-        </section>
-
-        <!-- Footer -->
-        <div class="govuk-footer__meta">
-            <div class="govuk-footer__meta-item govuk-footer__meta-item--grow">
-                <h2 class="govuk-visually-hidden">Support links</h2>
-                <ul class="govuk-footer__inline-list govuk-!-display-none-print">
-                    <li class="govuk-footer__inline-list-item">
-                      <a class="govuk-footer__link" data-ga4-link="{&quot;event_name&quot;:&quot;navigation&quot;,&quot;type&quot;:&quot;footer&quot;,&quot;index_link&quot;:&quot;1&quot;,&quot;index_section&quot;:&quot;3&quot;,&quot;index_section_count&quot;:&quot;5&quot;,&quot;index_total&quot;:&quot;8&quot;,&quot;section&quot;:&quot;Support links&quot;}" href="https://www.gov.uk/government/organisations/department-for-environment-food-rural-affairs">Department for Environment, Food & Rural Affairs (Defra)</a>
-                    </li>
-                    <li class="govuk-footer__inline-list-item">
-                      <a class="govuk-footer__link" data-ga4-link="{&quot;event_name&quot;:&quot;navigation&quot;,&quot;type&quot;:&quot;footer&quot;,&quot;index_link&quot;:&quot;1&quot;,&quot;index_section&quot;:&quot;3&quot;,&quot;index_section_count&quot;:&quot;5&quot;,&quot;index_total&quot;:&quot;8&quot;,&quot;section&quot;:&quot;Support links&quot;}" href="https://www.gov.uk/help">Help</a>
-                    </li>
-                    <li class="govuk-footer__inline-list-item">
-                      <a class="govuk-footer__link" data-ga4-link="{&quot;event_name&quot;:&quot;navigation&quot;,&quot;type&quot;:&quot;footer&quot;,&quot;index_link&quot;:&quot;2&quot;,&quot;index_section&quot;:&quot;3&quot;,&quot;index_section_count&quot;:&quot;5&quot;,&quot;index_total&quot;:&quot;8&quot;,&quot;section&quot;:&quot;Support links&quot;}" href="https://www.gov.uk/help/privacy-notice">Privacy</a>
-                    </li>
-                    <li class="govuk-footer__inline-list-item">
-                      <a class="govuk-footer__link" data-ga4-link="{&quot;event_name&quot;:&quot;navigation&quot;,&quot;type&quot;:&quot;footer&quot;,&quot;index_link&quot;:&quot;3&quot;,&quot;index_section&quot;:&quot;3&quot;,&quot;index_section_count&quot;:&quot;5&quot;,&quot;index_total&quot;:&quot;8&quot;,&quot;section&quot;:&quot;Support links&quot;}" href="https://www.gov.uk/help/cookies">Cookies</a>
-                    </li>
-                    <li class="govuk-footer__inline-list-item">
-                      <a class="govuk-footer__link" data-ga4-link="{&quot;event_name&quot;:&quot;navigation&quot;,&quot;type&quot;:&quot;footer&quot;,&quot;index_link&quot;:&quot;4&quot;,&quot;index_section&quot;:&quot;3&quot;,&quot;index_section_count&quot;:&quot;5&quot;,&quot;index_total&quot;:&quot;8&quot;,&quot;section&quot;:&quot;Support links&quot;}" href="https://www.gov.uk/help/accessibility-statement">Accessibility statement</a>
-                    </li>
-                    <li class="govuk-footer__inline-list-item">
-                      <a class="govuk-footer__link" data-ga4-link="{&quot;event_name&quot;:&quot;navigation&quot;,&quot;type&quot;:&quot;footer&quot;,&quot;index_link&quot;:&quot;5&quot;,&quot;index_section&quot;:&quot;3&quot;,&quot;index_section_count&quot;:&quot;5&quot;,&quot;index_total&quot;:&quot;8&quot;,&quot;section&quot;:&quot;Support links&quot;}" href="https://www.gov.uk/contact">Contact</a>
-                    </li>
-                    <li class="govuk-footer__inline-list-item">
-                      <a class="govuk-footer__link" data-ga4-link="{&quot;event_name&quot;:&quot;navigation&quot;,&quot;type&quot;:&quot;footer&quot;,&quot;index_link&quot;:&quot;6&quot;,&quot;index_section&quot;:&quot;3&quot;,&quot;index_section_count&quot;:&quot;5&quot;,&quot;index_total&quot;:&quot;8&quot;,&quot;section&quot;:&quot;Support links&quot;}" href="https://www.gov.uk/help/terms-conditions">Terms and conditions</a>
-                    </li>
-                    <li class="govuk-footer__inline-list-item">
-                      <a class="govuk-footer__link" lang="cy" data-ga4-link="{&quot;event_name&quot;:&quot;navigation&quot;,&quot;type&quot;:&quot;footer&quot;,&quot;index_link&quot;:&quot;7&quot;,&quot;index_section&quot;:&quot;3&quot;,&quot;index_section_count&quot;:&quot;5&quot;,&quot;index_total&quot;:&quot;8&quot;,&quot;section&quot;:&quot;Support links&quot;}" href="https://www.gov.uk/cymraeg">Rhestr o Wasanaethau Cymraeg</a>
-                    </li>
-                    <li class="govuk-footer__inline-list-item">
-                      <a class="govuk-footer__link" data-ga4-link="{&quot;event_name&quot;:&quot;navigation&quot;,&quot;type&quot;:&quot;footer&quot;,&quot;index_link&quot;:&quot;8&quot;,&quot;index_section&quot;:&quot;3&quot;,&quot;index_section_count&quot;:&quot;5&quot;,&quot;index_total&quot;:&quot;8&quot;,&quot;section&quot;:&quot;Support links&quot;}" href="https://www.gov.uk/government/organisations/government-digital-service">Government Digital Service</a>
-                    </li>
-                </ul>
-                <div class="govuk-footer__meta-item govuk-footer__meta-item--grow">
-                  <svg
-                    aria-hidden="true"
-                    focusable="false"
-                    class="govuk-footer__licence-logo"
-                    xmlns="http://www.w3.org/2000/svg"
-                    viewBox="0 0 483.2 195.7"
-                    height="17"
-                    width="41">
-                    <path
-                      fill="currentColor"
-                      d="M421.5 142.8V.1l-50.7 32.3v161.1h112.4v-50.7zm-122.3-9.6A47.12 47.12 0 0 1 221 97.8c0-26 21.1-47.1 47.1-47.1 16.7 0 31.4 8.7 39.7 21.8l42.7-27.2A97.63 97.63 0 0 0 268.1 0c-36.5 0-68.3 20.1-85.1 49.7A98 98 0 0 0 97.8 0C43.9 0 0 43.9 0 97.8s43.9 97.8 97.8 97.8c36.5 0 68.3-20.1 85.1-49.7a97.76 97.76 0 0 0 149.6 25.4l19.4 22.2h3v-87.8h-80l24.3 27.5zM97.8 145c-26 0-47.1-21.1-47.1-47.1s21.1-47.1 47.1-47.1 47.2 21 47.2 47S123.8 145 97.8 145" />
-                  </svg>
-                  <span class="govuk-footer__licence-description">
-                    All content is available under the
-                    <a
-                      class="govuk-footer__link"
-                      href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/"
-                      rel="license">Open Government Licence v3.0</a>, except where otherwise stated
-                  </span>
-                </div>
-                <br/>
-                <div class="govuk-footer__meta-item">
-                  <a
-                    class="govuk-footer__link govuk-footer__copyright-logo"
-                    href="https://www.nationalarchives.gov.uk/information-management/re-using-public-sector-information/uk-government-licensing-framework/crown-copyright/">
-                    <img src="{{ '/assets/images/govuk-crest.svg' | relative_url }}" alt="GOV.UK crest" width="125" height="102" />
-                    <br/>
-                    © Crown copyright
-                  </a>
-                </div>
-              </div>
-            </div>
+          <div class="govuk-footer__meta-item govuk-footer__meta-item--grow">
+            <svg aria-hidden="true" focusable="false" class="govuk-footer__licence-logo"
+              xmlns="http://www.w3.org/2000/svg" viewBox="0 0 483.2 195.7" height="17" width="41">
+              <path fill="currentColor"
+                d="M421.5 142.8V.1l-50.7 32.3v161.1h112.4v-50.7zm-122.3-9.6A47.12 47.12 0 0 1 221 97.8c0-26 21.1-47.1 47.1-47.1 16.7 0 31.4 8.7 39.7 21.8l42.7-27.2A97.63 97.63 0 0 0 268.1 0c-36.5 0-68.3 20.1-85.1 49.7A98 98 0 0 0 97.8 0C43.9 0 0 43.9 0 97.8s43.9 97.8 97.8 97.8c36.5 0 68.3-20.1 85.1-49.7a97.76 97.76 0 0 0 149.6 25.4l19.4 22.2h3v-87.8h-80l24.3 27.5zM97.8 145c-26 0-47.1-21.1-47.1-47.1s21.1-47.1 47.1-47.1 47.2 21 47.2 47S123.8 145 97.8 145" />
+            </svg>
+            <span class="govuk-footer__licence-description">
+              All content is available under the
+              <a class="govuk-footer__link"
+                href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/" rel="license">Open
+                Government Licence v3.0</a>, except where otherwise stated
+            </span>
           </div>
+          <br />
+          <div class="govuk-footer__meta-item">
+            <a class="govuk-footer__link govuk-footer__copyright-logo"
+              href="https://www.nationalarchives.gov.uk/information-management/re-using-public-sector-information/uk-government-licensing-framework/crown-copyright/">
+              <img src="{{ '/assets/images/govuk-crest.svg' | relative_url }}" alt="GOV.UK crest" width="125"
+                height="102" />
+              <br />
+              © Crown copyright
+            </a>
+          </div>
+        </div>
       </div>
     </div>
-    <script src="{{ "/assets/js/scale.fix.js" | relative_url }}"></script>
-    <script>
-      // Dark mode toggle functionality
-      const themeToggle = document.querySelector('.theme-toggle-checkbox');
-      const html = document.documentElement;
-      
-      // Check for saved theme preference, otherwise use system preference
-      const getPreferredTheme = () => {
-        const savedTheme = localStorage.getItem('theme');
-        if (savedTheme) {
-          return savedTheme;
-        }
-        return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
-      };
+  </div>
+  </div>
+  <script src="{{ " /assets/js/scale.fix.js" | relative_url }}"></script>
+  <script>
+    // Dark mode toggle functionality
+    const themeToggle = document.querySelector('.theme-toggle-checkbox');
+    const html = document.documentElement;
 
-      // Apply theme
-      const setTheme = (theme) => {
-        html.setAttribute('data-theme', theme);
-        localStorage.setItem('theme', theme);
-        themeToggle.checked = theme === 'dark';
-      };
+    // Check for saved theme preference, otherwise use system preference
+    const getPreferredTheme = () => {
+      const savedTheme = localStorage.getItem('theme');
+      if (savedTheme) {
+        return savedTheme;
+      }
+      return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+    };
 
-      // Initial theme setup
-      setTheme(getPreferredTheme());
+    // Apply theme
+    const setTheme = (theme) => {
+      html.setAttribute('data-theme', theme);
+      localStorage.setItem('theme', theme);
+      themeToggle.checked = theme === 'dark';
+    };
 
-      // Toggle theme
-      themeToggle.addEventListener('change', () => {
-        const newTheme = themeToggle.checked ? 'dark' : 'light';
-        setTheme(newTheme);
-      });
+    // Initial theme setup
+    setTheme(getPreferredTheme());
 
-      // Listen for system theme changes
-      window.matchMedia('(prefers-color-scheme: dark)').addEventListener('change', (e) => {
-        if (!localStorage.getItem('theme')) {
-          setTheme(e.matches ? 'dark' : 'light');
-        }
-      });
-    </script>
-  </body>
+    // Toggle theme
+    themeToggle.addEventListener('change', () => {
+      const newTheme = themeToggle.checked ? 'dark' : 'light';
+      setTheme(newTheme);
+    });
+
+    // Listen for system theme changes
+    window.matchMedia('(prefers-color-scheme: dark)').addEventListener('change', (e) => {
+      if (!localStorage.getItem('theme')) {
+        setTheme(e.matches ? 'dark' : 'light');
+      }
+    });
+  </script>
+</body>
+
 </html>

--- a/_sass/defra-styles.scss
+++ b/_sass/defra-styles.scss
@@ -143,8 +143,11 @@ a:active {
   checked: true;
 }
 
-// Wrapper styling
+// Wrapper styling — override base theme width (860px) to fit sidebar + content
 .wrapper {
+  width: auto;
+  max-width: 1000px;
+  margin: 0 auto;
   display: flex;
   flex-direction: row;
   min-height: 100vh;
@@ -154,6 +157,7 @@ a:active {
 // Navigation styling
 .navigation {
   width: 270px;
+  flex-shrink: 0;
   padding: 2rem 1rem;
   background: var(--nav-bg);
   border-right: 1px solid var(--border-color);
@@ -181,8 +185,18 @@ a:active {
   background-color: var(--bg-color);
 }
 
+// Override base theme float layout — the minimal theme uses floats and fixed widths
+// which break our flex layout
 section {
   float: none;
+  width: auto;
+  padding-bottom: 0;
+}
+
+header {
+  float: none;
+  width: auto;
+  position: relative;
 }
 
 // Navigation menu styling

--- a/tool-setup/cross-tool-config.md
+++ b/tool-setup/cross-tool-config.md
@@ -1,0 +1,201 @@
+# Using these examples with other AI tools
+
+The agents, instructions, and prompts on this site are written for GitHub Copilot's configuration format, but the **content** — the rules, standards, and patterns — works with any AI coding tool. This page shows how to adapt the examples for other tools.
+
+## How the content maps across tools
+
+Every AI coding tool has its own configuration format, but they all solve the same problem: giving the AI context about your project. The table below shows where each tool expects to find that context.
+
+### GitHub Copilot
+
+| Concept | Configuration |
+|---------|--------------|
+| **Root instructions** | `.github/copilot-instructions.md` |
+| **Scoped instructions** | `.github/instructions/**/*.instructions.md` with `applyTo` frontmatter |
+| **Agents** | `.github/agents/*.agent.md` |
+| **Prompts** | `.github/prompts/*.prompt.md` |
+
+### Claude Code
+
+| Concept | Configuration |
+|---------|--------------|
+| **Root instructions** | `CLAUDE.md` in repo root |
+| **Scoped instructions** | `CLAUDE.md` in subdirectories, or `.claude/rules/*.md` with `paths` frontmatter |
+| **Agents** | `.claude/agents/` for custom subagents |
+| **Prompts** | `.claude/commands/*.md` (custom slash commands) |
+
+### Cursor
+
+| Concept | Configuration |
+|---------|--------------|
+| **Root instructions** | `.cursor/rules/*.mdc` with `alwaysApply: true` |
+| **Scoped instructions** | `.cursor/rules/*.mdc` with `globs` frontmatter |
+| **Agents** | Not supported — use rules instead |
+| **Prompts** | Not supported — paste into chat |
+
+### Windsurf
+
+| Concept | Configuration |
+|---------|--------------|
+| **Root instructions** | `.windsurf/rules/*.md` with Always On trigger (legacy: `.windsurfrules`) |
+| **Scoped instructions** | `.windsurf/rules/*.md` with Glob trigger |
+| **Agents** | Supports `AGENTS.md` |
+| **Prompts** | Not supported — paste into chat |
+
+## Adapting the examples
+
+### Claude Code
+
+Claude Code reads project context from `CLAUDE.md` files and `.claude/` configuration. To use the Defra examples:
+
+1. Create a `CLAUDE.md` in your repo root with the content from [copilot-instructions.md]({{ "/tool-setup/github-copilot/instructions/copilot-instructions" | relative_url }})
+2. Append the relevant backend instructions ([Node.js]({{ "/tool-setup/github-copilot/instructions/node-backend" | relative_url }}) or [C#]({{ "/tool-setup/github-copilot/instructions/csharp-backend" | relative_url }}))
+3. Append the [frontend instructions]({{ "/tool-setup/github-copilot/instructions/frontend" | relative_url }}) if your service has a UI
+4. Replace `applyTo` frontmatter with `paths` frontmatter in any `.claude/rules/*.md` files
+
+For scoped rules, you have two options:
+
+**Option A — subdirectory `CLAUDE.md` files** (simpler):
+
+```
+your-repo/
+├── CLAUDE.md                    # Root instructions (always active)
+├── src/
+│   └── CLAUDE.md                # Backend-specific rules
+└── views/
+    └── CLAUDE.md                # Frontend-specific rules
+```
+
+**Option B — `.claude/rules/` with `paths` frontmatter** (more precise):
+
+```
+your-repo/
+├── CLAUDE.md                    # Root instructions
+└── .claude/
+    └── rules/
+        ├── node-backend.md      # Scoped to JS/MJS files
+        └── frontend.md          # Scoped to Nunjucks/SCSS files
+```
+
+Each rule file uses `paths` frontmatter to target specific file patterns:
+
+```yaml
+---
+paths:
+  - "**/*.js"
+  - "**/*.mjs"
+---
+```
+
+**Agent content**: Claude Code supports custom subagents via `.claude/agents/`. Create agent definitions here to replicate the behaviour of the [Defra App Developer agent]({{ "/tool-setup/github-copilot/agents/defra-app-developer" | relative_url }}).
+
+**Prompt content**: Claude Code supports custom slash commands via `.claude/commands/*.md`. Each file becomes a reusable command invoked as `/project:command-name`. Files can include `$ARGUMENTS` as a placeholder for dynamic input.
+
+Example — `.claude/commands/review.md`:
+
+```markdown
+Review the code in $ARGUMENTS for:
+- Security vulnerabilities (OWASP Top 10)
+- Accessibility issues (WCAG 2.2 AA)
+- Defra coding standards compliance
+```
+
+Invoke with: `/project:review src/controllers/auth.js`
+
+### Cursor
+
+Cursor uses rule files in `.cursor/rules/`. To use the Defra examples:
+
+1. Create `.cursor/rules/` in your repository root
+2. Copy the root instructions into a `.mdc` file with `alwaysApply: true`
+3. Copy scoped instructions into separate files with `globs` frontmatter
+4. Update the frontmatter from `applyTo` to `globs`:
+
+**Copilot format:**
+```yaml
+---
+applyTo: "**/*.js,**/*.mjs"
+---
+```
+
+**Cursor format:**
+```yaml
+---
+description: Node.js backend rules
+globs: "**/*.js,**/*.mjs"
+alwaysApply: false
+---
+```
+
+Cursor supports four rule types controlled by frontmatter:
+
+| Rule type | Frontmatter | Behaviour |
+|-----------|-------------|-----------|
+| **Always** | `alwaysApply: true` | Always included in context (root instructions) |
+| **Auto Attached** | `globs: "pattern"` | Included when matching files are referenced |
+| **Agent Requested** | `description: "..."` only | AI reads description and decides whether to include |
+| **Manual** | No description, no globs | Only included when explicitly referenced with `@rulename` |
+
+**Agent and prompt content**: Cursor does not have separate agent or prompt files. Merge agent rules into your rule files and paste prompt templates into the chat when needed.
+
+### Windsurf
+
+Windsurf uses a rules directory at `.windsurf/rules/`. To use the Defra examples:
+
+1. Create `.windsurf/rules/` in your repository root
+2. Create an always-on rule file with root instructions
+3. Create scoped rule files with Glob triggers for backend and frontend rules
+4. Set the appropriate trigger type in each file's frontmatter
+
+**Windsurf rule frontmatter:**
+
+```yaml
+---
+trigger: glob
+globs: ["**/*.js", "**/*.mjs"]
+description: Node.js backend rules
+---
+```
+
+Windsurf supports four trigger types:
+
+| Trigger | Behaviour |
+|---------|-----------|
+| `always_on` | Always included in context (root instructions) |
+| `glob` | Included when matching files are referenced (scoped instructions) |
+| `model_decision` | AI reads description and decides whether to include |
+| `manual` | Only included when explicitly referenced by the user |
+
+**Legacy**: `.windsurfrules` in the repo root still works as a single-file alternative. Use it if your team does not need scoped rules.
+
+**Agent content**: Windsurf supports `AGENTS.md` for defining agent personas.
+
+**Prompt content**: Windsurf does not have a prompt file system. Paste prompt templates into the chat when needed.
+
+## What stays the same across tools
+
+Regardless of the tool, the underlying rules are identical:
+
+- Defra software development standards
+- GOV.UK Design System and content standards
+- WCAG 2.2 Level AA accessibility
+- OWASP security practices
+- SonarCloud quality gates (SonarWay profile)
+- Coding conventions (ESLint + Prettier, vanilla JS, Hapi, joi)
+- Test coverage targets (90% minimum)
+- No PII in logs, no secrets in code
+
+The format changes. The standards do not.
+
+## Multi-tool setup
+
+If your team uses multiple AI tools, maintain the content in one place and generate tool-specific config files from it. One approach:
+
+1. Write your canonical rules in `.github/copilot-instructions.md` (this is version-controlled and reviewed in PRs)
+2. Use the [scaffold prompt]({{ "/tool-setup/github-copilot/prompts/scaffold-repo" | relative_url }}) to generate the initial config
+3. Copy the same content into `CLAUDE.md`, `.cursor/rules/`, or `.windsurf/rules/` as needed
+4. When rules change, update the canonical source and regenerate
+
+---
+
+[Back to Tool Setup]({{ "/tool-setup" | relative_url }}) · [Back to GitHub Copilot setup guide]({{ "/tool-setup/github-copilot-setup" | relative_url }})

--- a/tool-setup/cursor-setup.md
+++ b/tool-setup/cursor-setup.md
@@ -1,0 +1,84 @@
+# Cursor — Setup Guide
+
+This guide explains how to configure Cursor for Defra projects using rule files. The examples provided encode [Defra software development standards](https://github.com/DEFRA/software-development-standards) so Cursor produces compliant code from the start.
+
+For a general overview of how AI tool configuration maps across tools, see [Using these examples with other AI tools]({{ "/tool-setup/cross-tool-config" | relative_url }}).
+
+## How Cursor uses rule files
+
+Cursor reads project-specific rules from `.cursor/rules/` in your repository. Each rule file uses the `.mdc` extension and controls when it activates using frontmatter.
+
+There are four rule types:
+
+| Rule type | Frontmatter | When it activates |
+|-----------|-------------|-------------------|
+| **Always** | `alwaysApply: true` | Every Cursor interaction (root instructions) |
+| **Auto Attached** | `globs: "pattern"` | When files matching the pattern are referenced |
+| **Agent Requested** | `description: "..."` only | Cursor reads the description and decides whether to include |
+| **Manual** | No description, no globs | Only when explicitly referenced with `@rulename` |
+
+Read more in the [Cursor documentation (opens in new tab)](https://docs.cursor.com/context/rules){:target="_blank"}.
+
+## Recommended directory structure
+
+```
+your-repo/
+└── .cursor/
+    └── rules/
+        ├── project.mdc                # Project overview (always active)
+        ├── javascript-api.mdc         # Node.js/Hapi backend rules
+        ├── gov-uk-standards.mdc       # GOV.UK frontend and Nunjucks
+        ├── mongodb-patterns.mdc       # MongoDB data access patterns
+        ├── api-testing.mdc            # Jest API testing standards
+        ├── playwright-testing.mdc     # Playwright journey tests
+        ├── restful-api-patterns.mdc   # RESTful route and handler patterns
+        ├── api-integration.mdc        # API client integration patterns
+        └── navigation.mdc            # Navigation and routing patterns
+```
+
+## Example rule files
+
+These example files contain the same Defra standards encoded in the [GitHub Copilot examples]({{ "/tool-setup/github-copilot-setup" | relative_url }}), adapted for Cursor's rule file format.
+
+### Node.js
+
+- [Node.js backend rules]({{ "/tool-setup/cursor/nodejs-backend-rules" | relative_url }}) — Hapi, vanilla JS, MongoDB, REST API patterns, Jest testing
+- [Node.js frontend rules]({{ "/tool-setup/cursor/nodejs-frontend-rules" | relative_url }}) — GOV.UK Design System, Nunjucks, Playwright testing, accessibility
+
+### Python
+
+- [Python backend rules]({{ "/tool-setup/cursor/python-backend-rules" | relative_url }}) — FastAPI, pytest, MongoDB mocking patterns
+
+## How to use these examples
+
+1. Create `.cursor/rules/` in your repository root
+2. Browse the example files above and copy the rule content into separate `.mdc` files
+3. Each code block in the example files represents one `.mdc` file — the filename is shown in bold above each block
+4. Edit the project overview rule to describe your specific service
+5. Remove or modify rules that do not match your tech stack
+
+## Adapting GitHub Copilot examples for Cursor
+
+If you are starting from a GitHub Copilot configuration, convert the frontmatter:
+
+**Copilot format:**
+```yaml
+---
+applyTo: "**/*.js,**/*.mjs"
+---
+```
+
+**Cursor format:**
+```yaml
+---
+description: Node.js backend rules
+globs: "**/*.js,**/*.mjs"
+alwaysApply: false
+---
+```
+
+See [Using these examples with other AI tools]({{ "/tool-setup/cross-tool-config" | relative_url }}) for the full adaptation guide.
+
+---
+
+[Back to Tool Setup]({{ "/tool-setup" | relative_url }})

--- a/tool-setup/cursor/nodejs-backend-rules.md
+++ b/tool-setup/cursor/nodejs-backend-rules.md
@@ -1,0 +1,672 @@
+# Node.js Backend — Cursor Rule Files
+
+The set of Cursor rule files for Node.js backend applications.
+
+Cursor saves rule files in the repository in the `.cursor/rules` directory. Each section below is a separate `.mdc` file in this directory.
+
+These rules encode the same [Defra software development standards](https://github.com/DEFRA/software-development-standards) as the [GitHub Copilot Node.js backend instructions]({{ "/tool-setup/github-copilot/instructions/node-backend" | relative_url }}), adapted for Cursor's rule file format.
+
+---
+
+**api-testing.mdc**
+````
+---
+description: API Testing Standards
+globs: tests/*.js
+---
+# API Testing Standards
+
+## Test Structure
+```javascript
+import { describe, test, expect, beforeEach } from '@jest/globals'
+import { init } from '../server.js'
+
+describe('Resource API', () => {
+  let server
+
+  beforeEach(async () => {
+    server = await init()
+  })
+
+  afterEach(async () => {
+    await server.stop()
+  })
+
+  test('GET /api/v1/resource should return list', async () => {
+    const response = await server.inject({
+      method: 'GET',
+      url: '/api/v1/resource'
+    })
+    expect(response.statusCode).toBe(200)
+  })
+})
+```
+
+## Testing Patterns
+- Test HTTP status codes
+- Test response payload structure
+- Test error scenarios
+- Test input validation
+- Test authentication/authorization
+- Mock external services
+- Use proper test isolation
+
+## Best Practices
+- One assertion per test
+- Clear test descriptions
+- Setup/teardown in beforeEach/afterEach
+- Clean test data between runs
+- Test edge cases
+- Test error handling
+- Use test factories for data creation
+
+## Unit Testing
+- Test complete request/response cycle
+- Test database interactions
+- Test external service integration
+- Test authentication flow
+- Test rate limiting
+- Test concurrent requests
+
+## Performance Testing
+- Response time benchmarks
+- Load testing critical endpoints
+- Memory usage monitoring
+- Connection pool behavior
+- Database query performance
+````
+
+---
+
+**javascript-api.mdc**
+````
+---
+description: Javascript API Standards
+globs: *.js
+---
+# JavaScript API Standards
+
+## Language & Runtime
+- Node.js (Active LTS)
+- JavaScript (ES2022+)
+- Do not use TypeScript without an approved exception — use JSDoc for type annotations
+
+## Tech Stack
+- Hapi.js for API framework
+- Jest for testing
+- ESLint + Prettier
+- OpenAPI/Swagger for API documentation
+- convict for configuration
+
+## Code Standards
+- Use vanilla JavaScript with JSDoc type annotations
+- Use ES Modules with named exports
+- Use absolute imports with '~' alias
+- Follow RESTful API design principles
+- Use async/await for asynchronous operations
+- Implement proper error handling and logging
+
+## Project Structure
+```
+/src
+  /config/         # Configuration management
+  /api/           
+    /v1/           # API version
+      /{resource}/ # Resource modules
+        routes.js    # Route definitions
+        handler.js   # Request handlers
+        schema.js    # Joi validation schemas
+        service.js   # Business logic
+        model.js     # Data models
+        *.test.js   # Unit tests
+  /services/      # Shared services
+  /utils/         # Utility functions
+  /middleware/    # Custom middleware
+  /db/           # Database connections
+  server.js      # Server setup
+```
+
+## API Patterns
+- Use proper HTTP methods (GET, POST, PUT, DELETE)
+- Implement consistent error responses
+- Version APIs in URL (/api/v1/...)
+- Use query parameters for filtering/sorting
+- Implement pagination for list endpoints
+- Rate limiting on all endpoints
+- Request validation with Joi
+- Response validation with Joi
+
+## Error Handling
+- Use standardized error response format:
+```javascript
+{
+  statusCode: number,
+  error: string,
+  message: string,
+  details?: any
+}
+```
+- Log errors with appropriate severity
+- Handle async errors with try/catch
+- Use custom error classes for business logic
+
+## Security
+- Implement authentication middleware
+- Validate all inputs
+- Sanitize all outputs
+- Use CORS appropriately
+- Rate limiting
+- Request size limits
+- Security headers
+
+## Testing
+- Unit test all handlers and services
+- Unit tests for API endpoints
+- Mock external dependencies
+- Test error scenarios
+- Test input validation
+- Test authentication/authorization
+
+## Documentation
+- OpenAPI/Swagger documentation
+- JSDoc for all functions
+- README for setup/deployment
+- API changelog
+````
+
+---
+
+**mongodb-patterns.mdc**
+````
+---
+description: MongoDB and Data Model Patterns
+globs: src/api/**/*.js
+---
+# MongoDB and Data Model Patterns
+
+## MongoDB Setup
+- Uses native MongoDB driver (not Mongoose)
+- Connection managed by `mongodb.js` plugin
+- MongoDB client available via:
+  - `server.db` - For server-level access
+  - `request.db` - For request handlers
+  - `server.locker` - For MongoDB locks
+  - `request.locker` - For request-level locks
+
+## Collection Naming
+- Use camelCase for collection names
+- Suffix with plural form (e.g., `governanceTemplates`)
+- Collection names defined in model files
+- Example: `collection: 'governanceTemplates'`
+
+## Data Models
+- Models defined in `model.js` files
+- Use TypeScript-style JSDoc for type definitions
+- Factory functions for creating documents
+- Always use ObjectId for foreign keys and _id fields
+- Example structure:
+```javascript
+/**
+ * @typedef {object} ModelName
+ * @property {import('mongodb').ObjectId} _id - The unique identifier
+ * @property {import('mongodb').ObjectId} parentId - Reference to parent (required)
+ * @property {string} name - The name field (required)
+ * @property {string} [description] - Optional description
+ * @property {Date} createdAt - When created (required)
+ * @property {Date} updatedAt - When last updated (required)
+ */
+
+export function createModel(data) {
+  const now = new Date()
+  return {
+    parentId: typeof data.parentId === 'string' 
+      ? new ObjectId(data.parentId) 
+      : data.parentId,
+    name: data.name,
+    description: data.description,
+    createdAt: now,
+    updatedAt: now
+  }
+}
+```
+
+## Schema Validation
+- Schema validation defined in `createSchemaValidation` function
+- Uses MongoDB's $jsonSchema validator
+- Enforces strict validation on all collections
+- Validation rules:
+  - Required fields must be present
+  - Field types must match specified BSON types
+  - Enums enforce allowed values
+  - ObjectIds for references and _id fields
+  - Dates for timestamps (createdAt, updatedAt)
+- Example schema:
+```javascript
+await db.command({
+  collMod: 'collectionName',
+  validator: {
+    $jsonSchema: {
+      bsonType: 'object',
+      required: ['parentId', 'name', 'createdAt', 'updatedAt'],
+      additionalProperties: false,
+      properties: {
+        _id: { bsonType: 'objectId' },
+        parentId: { bsonType: 'objectId' },
+        name: { bsonType: 'string' },
+        description: { bsonType: 'string' },
+        createdAt: { bsonType: 'date' },
+        updatedAt: { bsonType: 'date' },
+        status: { 
+          bsonType: 'string',
+          enum: ['active', 'inactive']
+        }
+      }
+    }
+  },
+  validationLevel: 'strict',
+  validationAction: 'error'
+})
+```
+
+## IDs and Foreign Keys
+- Always store _id and foreign key fields as ObjectIds, NEVER as strings
+- Convert string IDs to ObjectIds in factory functions
+- Use proper JSDoc types to document ObjectId fields
+- Example foreign key handling:
+```javascript
+// In model.js
+/**
+ * @typedef {object} ChildDocument
+ * @property {import('mongodb').ObjectId} _id
+ * @property {import('mongodb').ObjectId} parentId
+ */
+
+// In factory function
+export function createChild(data) {
+  return {
+    parentId: typeof data.parentId === 'string' 
+      ? new ObjectId(data.parentId) 
+      : data.parentId,
+    // ... other fields
+  }
+}
+
+// In controller
+async function findChildren(request) {
+  const parentId = new ObjectId(request.params.id)
+  return request.db
+    .collection('children')
+    .find({ parentId })
+    .toArray()
+}
+```
+
+## Indexes
+- Defined in `src/api/common/helpers/mongodb.js`
+- Created on application startup
+- Use compound indexes for uniqueness constraints
+- Always index foreign key fields
+- Example:
+```javascript
+// Index on foreign key
+await db.collection('children').createIndex({ parentId: 1 })
+
+// Compound unique index
+await db.collection('templates').createIndex(
+  { name: 1, version: 1 }, 
+  { unique: true }
+)
+```
+
+## Controllers
+- Use native MongoDB operations
+- Access DB via `request.db`
+- Common operations:
+  - `collection.insertOne()` - Create
+  - `collection.findOne()` - Read
+  - `collection.findOneAndUpdate()` - Update
+  - `collection.deleteOne()` - Delete
+- Handle MongoDB errors:
+  - `error.code === 11000` for duplicates
+  - Use Boom for HTTP errors
+
+## Example Usage
+```javascript
+// Model Definition
+/**
+ * @typedef {object} Template
+ * @property {string} name
+ * @property {string} version
+ */
+
+export function createTemplate(data) {
+  return {
+    name: data.name,
+    version: data.version
+  }
+}
+
+// Controller Usage
+async function handler(request, h) {
+  const doc = createTemplate(request.payload)
+  const result = await request.db
+    .collection('templates')
+    .insertOne(doc)
+  return h.response({ ...doc, _id: result.insertedId })
+}
+```
+
+## Validation
+- Use Joi schemas for input validation
+- Define schemas in `validation.js`
+- Use custom ObjectId validation for ID fields
+- Example:
+```javascript
+const objectIdSchema = Joi.string().custom((value, helpers) => {
+  if (!ObjectId.isValid(value)) {
+    return helpers.error('any.invalid')
+  }
+  return value
+}, 'MongoDB ObjectId validation')
+
+const schema = Joi.object({
+  parentId: objectIdSchema.required(),
+  name: Joi.string().required()
+})
+```
+
+## Error Handling
+- Use Boom for HTTP errors
+- Handle MongoDB specific errors:
+```javascript
+try {
+  await collection.insertOne(doc)
+} catch (error) {
+  if (error.code === 11000) {
+    throw Boom.conflict('Duplicate entry')
+  }
+  throw Boom.badRequest(error.message)
+}
+```
+
+## Best Practices
+1. Always use ObjectIds for _id and foreign key fields
+2. Convert string IDs to ObjectIds in factory functions
+3. Use proper JSDoc types for ObjectId fields
+4. Index all foreign key fields
+5. Validate ObjectIds in Joi schemas
+6. Use factory functions for document creation
+7. Define TypeScript-style JSDoc types
+8. Use MongoDB indexes for constraints
+9. Handle MongoDB-specific error codes
+10. Use request.db for database access
+11. Follow collection naming conventions
+12. Document all model properties
+13. Use Joi for input validation
+14. Return clean errors via Boom
+15. Use MongoDB's native features over application logic
+16. Enforce schema validation at database level 
+````
+
+---
+
+**playwright-testing.mdc**
+````
+---
+description: Playwright Testing
+globs: tests/*.js
+---
+# Playwright Testing Rules
+
+## Testing Philosophy
+- Focus on user-visible behavior and outcomes rather than internal implementation details.
+- Keep tests isolated, independent, and reflective of end-to-end user journeys.
+- Test server-rendered content and interactive behaviors from a user's perspective.
+- Ensure tests remain robust by avoiding strict mode locator violations through specific and scoped selectors.
+
+## Testing Strategy
+
+### Element Scoping and Selectors
+- Always scope element checks to their containing parent to avoid matching multiple elements.
+- Use relative selectors and `:has()` filters to narrow down to specific instances (e.g., table rows, details components).
+- Refine selectors with regex for whitespace and exact text when needed.
+- Avoid global page-level selectors for nested elements.
+
+#### Selector Priority
+1. Role-based selectors with exact text, e.g., `getByRole('button', { name: 'Submit', exact: true })`
+2. ARIA label selectors, e.g., `getByLabel('Search')`
+3. Component-specific class selectors with context filtering, e.g., `locator('.govuk-details__summary-text', { hasText: /Summary Text/ })`
+4. Scoped locators using `:has()` and `filter()` for parent-child relationships.
+5. Generic text matching as the last resort, e.g., `getByText('Content')`
+
+### State and Interaction Testing
+- Verify both initial and changed states of interactive components.
+- Test interactive behaviors like clicking to expand/collapse a details component and verify resulting state changes (e.g., checking for the `open` attribute).
+- Test keyboard interactions, attribute changes, and error states.
+- Ensure tests cover both default views and dynamic transitions.
+
+## Test Structure
+- Place tests in the `/tests` directory with a `.spec.js` extension.
+- Group related tests using `test.describe()`.
+- Use `test.beforeEach()` for common setup steps.
+- Write clear, descriptive test names (e.g., "should display error message when API fails").
+- Always use ES Module syntax with named imports (e.g. `import { test, expect } from '@playwright/test';`).
+
+## GDS Component Testing
+
+### Common GDS Component Selectors
+- **Details Component:**
+  ```javascript
+  // Target summary text within a details component
+  page.locator('span.govuk-details__summary-text', { hasText: /Summary Text/ });
+  // Target content within the details component
+  page.locator('div.govuk-details__text').filter({ hasText: /Content Text/ });
+  ```
+- **Table Component:**
+  ```javascript
+  // Target table by accessible caption or role
+  page.getByRole('table', { name: 'Caption Text' });
+  // Target a specific row using role and text
+  page.getByRole('row', { name: 'Row Content' });
+  // Use scoped selectors within a row
+  const row = page.getByRole('row', { name: 'Row Content' });
+  row.locator('.govuk-tag');
+  ```
+- **Tags:**
+  ```javascript
+  // Target a tag with specific text
+  page.locator('.govuk-tag', { hasText: 'Tag Text' });
+  // Verify tag color variants with regex matching
+  await expect(tag).toHaveClass(/govuk-tag--blue/);
+  await expect(tag).toHaveClass(/govuk-tag--green/);
+  await expect(tag).toHaveClass(/govuk-tag--red/);
+  ```
+- **Buttons:**
+  ```javascript
+  page.getByRole('button', { name: 'Button Text' });
+  ```
+
+### GDS Component Testing Patterns
+- **Details Component:**
+  - Test summary text visibility.
+  - Test expand/collapse functionality by clicking the summary and asserting the open attribute.
+  - Verify that the expanded content renders the expected text.
+  - Include keyboard accessibility tests.
+- **Tables:**
+  - Verify the presence of captions, headers, and cell content.
+  - Check responsive behavior using scoped selectors for rows.
+- **Form Components:**
+  - Test validation messages and error summaries.
+  - Verify correct display of hint texts and input states.
+
+### Accessibility Testing
+- Integrate axe-core (e.g., using `@axe-core/playwright`) to run automated accessibility scans.
+- Test keyboard navigation flows and focus management.
+- Verify that screen reader announcements are correct.
+- Check for meeting color contrast standards and proper ARIA attributes.
+- Example:
+  ```javascript
+  import AxeBuilder from '@axe-core/playwright';
+  const results = await new AxeBuilder({ page }).analyze();
+  expect(results.violations).toEqual([]);
+  ```
+
+### Server-Side Testing Considerations
+- Test complete user journeys including form submissions, redirects, and session handling.
+- Verify that server-rendered content is correct.
+- Include tests for error pages and status codes.
+- Ensure that navigation flows are smooth and predictable across the application.
+````
+
+---
+
+**restful-api-patterns.mdc**
+````
+---
+description: RESTful API Implementation Patterns
+globs: src/api/**/*.js
+---
+# RESTful API Implementation Patterns
+
+## Route Structure
+- Group routes by resource in `/api/v1/{resource}/`
+- Use plural nouns for resource names (e.g. `templates`, `users`)
+- Implement standard CRUD operations:
+  - GET /resource - List all
+  - POST /resource - Create new
+  - GET /resource/{id} - Get one
+  - PUT /resource/{id} - Update one
+  - DELETE /resource/{id} - Delete one
+
+## File Organization
+```
+/api/v1/{resource}/
+  routes.js      # Route definitions
+  handler.js     # Request handlers
+  schema.js      # Joi validation schemas
+  service.js     # Business logic
+  model.js       # Data model & factory functions
+```
+
+## Route Definition Pattern
+```javascript
+export default {
+  name: 'resource',
+  register: async (server) => {
+    server.route([
+      {
+        method: 'GET',
+        path: '/api/v1/resource',
+        handler: handlers.getAll,
+        options: {
+          tags: ['api'],
+          validate: {
+            query: schemas.list
+          }
+        }
+      },
+      {
+        method: 'GET',
+        path: '/api/v1/resource/{id}',
+        handler: handlers.getById,
+        options: {
+          tags: ['api'],
+          validate: {
+            params: schemas.id
+          }
+        }
+      }
+    ])
+  }
+}
+```
+
+## HTTP Status Codes
+- 200: Successful GET/PUT with response body
+- 201: Successful POST with new resource
+- 204: Successful DELETE (no response body) - Always use for successful DELETE operations, even if resource didn't exist
+- 400: Bad request / validation error
+- 404: Resource not found
+- 409: Conflict (e.g. duplicate entry)
+- 500: Server error
+
+## Handler Pattern
+```javascript
+export async function deleteResource(request, h) {
+  const { id } = request.params
+  await service.deleteResource(request.db, id)
+  // Always return 204 for DELETE, regardless of whether resource existed
+  return h.response().code(204)
+}
+
+export async function createResource(request, h) {
+  const result = await service.createResource(request.db, request.payload)
+  return h.response(result).code(201)
+}
+```
+
+## Service Layer Pattern
+```javascript
+export async function getResource(db, id) {
+  const result = await db
+    .collection('resources')
+    .findOne({ _id: new ObjectId(id) })
+  
+  if (!result) {
+    throw Boom.notFound('Resource not found')
+  }
+  
+  return result
+}
+```
+
+## Validation Schema Pattern
+```javascript
+export const schemas = {
+  id: Joi.object({
+    id: Joi.string().required()
+  }),
+  create: Joi.object({
+    name: Joi.string().required(),
+    description: Joi.string()
+  })
+}
+```
+
+## Query Parameters
+- Use consistent parameter names:
+  - `page`: Page number for pagination
+  - `limit`: Items per page
+  - `sort`: Sort field
+  - `order`: Sort direction (asc/desc)
+  - `filter`: Filter criteria
+  - `fields`: Field selection
+
+## Response Envelope
+```javascript
+{
+  data: [],           // Resource data
+  meta: {            // Optional metadata
+    total: number,
+    page: number,
+    limit: number
+  }
+}
+```
+
+## Best Practices
+1. Use plural nouns for resource endpoints
+2. Return 204 for successful DELETE operations - Do not check if resource existed, always return 204 on successful execution
+3. Include validation for all inputs
+4. Use service layer for business logic
+5. Implement proper error handling
+6. Use consistent response formats
+7. Document with OpenAPI/Swagger
+8. Include proper CORS headers
+9. Implement rate limiting
+10. Version APIs in URL path
+````
+
+---
+
+[Back to Cursor setup guide]({{ "/tool-setup/cursor-setup" | relative_url }}) · [Back to Tool Setup]({{ "/tool-setup" | relative_url }})

--- a/tool-setup/cursor/nodejs-frontend-rules.md
+++ b/tool-setup/cursor/nodejs-frontend-rules.md
@@ -1,0 +1,504 @@
+# Node.js Frontend — Cursor Rule Files
+
+The set of Cursor rule files for Node.js frontend applications.
+
+Cursor saves rule files in the repository in the `.cursor/rules` directory. Each section below is a separate `.mdc` file in this directory.
+
+These rules encode the same [Defra software development standards](https://github.com/DEFRA/software-development-standards) as the [GitHub Copilot frontend instructions]({{ "/tool-setup/github-copilot/instructions/frontend" | relative_url }}), adapted for Cursor's rule file format.
+
+---
+
+**api-integration.mdc**
+````
+---
+description: API Integration Standards
+globs: src/**/*.js
+---
+# API Integration Standards
+
+## Configuration
+- Use apiServer from config for base URL:
+```javascript
+import { config } from '~/src/config/config.js'
+const baseUrl = config.get('apiServer')
+```
+
+## Making API Calls
+- Use native fetch for HTTP requests (do not use Axios or other HTTP clients)
+- Always include error handling
+- Use JSON content type by default
+- Follow RESTful conventions
+- Use absolute imports with '~' alias
+
+### Standard Pattern
+
+```javascript
+import { config } from '~/src/config/config.js'
+import { statusCodes } from '~/src/server/common/constants/status-codes.js'
+async function makeApiCall(request) {
+try {
+const response = await fetch(${config.get('apiServer')}/api/v1/endpoint, {
+method: 'POST',
+headers: {
+'Content-Type': 'application/json'
+},
+body: JSON.stringify(data)
+})
+if (!response.ok) {
+throw new Error(API call failed with status: ${response.status})
+}
+return await response.json()
+} catch (error) {
+request.logger.error(error)
+throw error
+}
+}
+```
+
+
+## Error Handling
+- Check response.ok status
+- Log errors with request.logger
+- Use statusCodes constants for response codes
+- Return user-friendly error messages
+- Propagate errors up for handling
+
+## Response Processing 
+- Parse JSON responses
+- Validate response data structure
+- Handle empty responses appropriately
+- Use TypeScript-style JSDoc for type annotations
+
+## Security
+- Use HTTPS in production
+- Include authorization headers when required
+- Redact sensitive data in logs
+- Follow security best practices
+````
+
+---
+
+**javascript.mdc**
+````
+---
+description: Javascript in Defra
+globs: *.js
+---
+# JavaScript in Defra
+
+## Language
+- Vanilla JavaScript
+- Do not use TypeScript without an approved exception — use JSDoc for type annotations
+
+## Tech Stack
+- Node.js + Hapi.js (do NOT use Express)
+- govuk-frontend npm library
+- Nunjucks templates npm library
+- Webpack + Babel
+- Jest + ESLint + Prettier
+- SCSS + PostCSS + Stylelint
+
+## Code Standards
+- Use vanilla JavaScript — do not use TypeScript without an approved exception
+- Use JSDoc for type annotations
+- Use ES Modules with named exports
+- Use absolute imports with '~' alias for internal project files
+- Use convict for configuration management
+- Use BEM-style naming with 'app-' prefix
+
+## Project Structure
+- /src/client/ - Client Side rendered (e.g. window operations)
+  - /javascripts
+    - /feature1 - Grouped by features
+- /src/config/ - Configuration and setup
+  - /nunjucks/ - Template engine setup
+    - /filters/ - Custom Nunjucks filters
+    - /globals/ - Global template variables
+- /src/server/ - Server-side code
+  - /common/ - Shared components and utilities
+    - /templates/ - Base templates and layouts
+    - /components/ - Reusable view components
+  - /{feature}/ - Feature modules
+    - controller.js - Route handlers and business logic
+    - controller.test.js - Unit tests
+    - index.js - Route definitions
+    - /views/ - Feature-specific templates
+  - router.js - Main route aggregation
+  - index.js - Server setup and plugins
+
+## Controller Patterns
+- Export named functions
+- Use JSDoc to document parameters
+- Standard parameters: (request, h)
+- Consistent error handling:
+  - Try/catch blocks
+  - Error logging with request.logger
+  - User-friendly error responses
+- Use h.view for template rendering
+- Use h.redirect for navigation
+
+## API Integration
+- Use fetch for API calls
+- Base URL from config
+- JSON content type
+- Response status checking
+- Error propagation
+- Consistent error handling
+
+## Configuration
+- Use config module for settings
+- Environment-based configuration
+- Consistent config access pattern
+- Type-safe config values
+
+## Markdown Parsing
+- Use marked library for parsing markdown
+- Configure marked options to match GDS styling
+- Always sanitize markdown output
+- Common use cases:
+  - Standards content
+  - Documentation
+  - Help text
+
+## Testing
+- Write comprehensive Jest tests
+- Test functionality, not implementation
+  - End-to-end coverage
+  - API: test input/output
+  - UI: test behavior + use data-testid
+- Use describe blocks and beforeEach for setup
+- Mock external dependencies
+
+## Template Handling
+- Configure Nunjucks search paths in nunjucks.js:
+  - govuk-frontend templates
+  - project views directory
+  - common templates
+  - common components
+- Use h.view with template paths relative to search paths
+- Bind controller methods when used as route handlers
+- Follow template inheritance patterns from gov-uk-standards
+- Keep templates close to their feature modules
+````
+
+---
+
+**gov-uk-standards.mdc**
+````
+---
+description: GOV.UK Frontend
+globs: *.njk, *.js
+---
+# GOV UK Frontend
+
+## Tech Stack
+- Node.js + Hapi.js
+- govuk-frontend npm library
+- Nunjucks templates
+
+## Template Structure
+- Use layouts/page.njk as base template
+- Follow GDS template hierarchy
+- Required template blocks:
+  - pageTitle: Page title with " - Defra SDLC Governance Checklist" suffix
+  - content: Main content area
+- Use govuk-width-container for page layout
+- Use govuk-main-wrapper for main content
+- Use govuk-grid-row and govuk-grid-column-* for grid layouts
+
+## Template Inheritance
+- Always use search path style imports (e.g. {% raw %}{% extends "layouts/page.njk" %}{% endraw %})
+- Never use relative paths in extends/include statements
+- Base template is at src/server/common/templates/layouts/page.njk
+- Feature templates should be in src/server/{feature}/views/
+- Common components in src/server/common/components/
+
+## Component Usage
+- Use GDS components with data-module="govuk-button" where needed
+- Follow GDS class naming:
+  - Headings: govuk-heading-xl, govuk-heading-l, etc.
+  - Body text: govuk-body
+  - Tables: govuk-table with appropriate child classes
+  - Buttons: govuk-button, govuk-button--warning for variants
+  - Forms: govuk-form-group, govuk-input, etc.
+  - Error handling: govuk-error-message, govuk-error-summary
+
+## Content Guidelines
+- Follow GDS content patterns
+- Use appropriate heading hierarchy
+- Ensure accessible content structure
+- Include proper ARIA roles and attributes
+- Use semantic HTML elements
+
+## Error Handling
+- Use consistent error templates
+- Display user-friendly error messages
+- Include status codes where appropriate
+- Provide clear next steps for users
+
+## Navigation
+- Use buildNavigation helper for consistent nav
+- Implement breadcrumbs where appropriate
+- Clear call-to-action buttons
+- Logical page flow
+
+## Nunjucks Filters
+- Custom filters located in src/config/nunjucks/filters/
+- Each filter should have its own file
+- Common filters:
+  - formatDate
+  - formatCurrency
+  - markdown (for content formatting)
+````
+
+---
+
+**playwright-testing.mdc**
+````
+---
+description: Playwright Testing
+globs: tests/*.js
+---
+# Playwright Testing Rules
+
+## Testing Philosophy
+- Focus on user-visible behavior and outcomes rather than internal implementation details.
+- Keep tests isolated, independent, and reflective of end-to-end user journeys.
+- Test server-rendered content and interactive behaviors from a user's perspective.
+- Ensure tests remain robust by avoiding strict mode locator violations through specific and scoped selectors.
+
+## Testing Strategy
+
+### Element Scoping and Selectors
+- Always scope element checks to their containing parent to avoid matching multiple elements.
+- Use relative selectors and `:has()` filters to narrow down to specific instances (e.g., table rows, details components).
+- Refine selectors with regex for whitespace and exact text when needed.
+- Avoid global page-level selectors for nested elements.
+
+#### Selector Priority
+1. Role-based selectors with exact text, e.g., `getByRole('button', { name: 'Submit', exact: true })`
+2. ARIA label selectors, e.g., `getByLabel('Search')`
+3. Component-specific class selectors with context filtering, e.g., `locator('.govuk-details__summary-text', { hasText: /Summary Text/ })`
+4. Scoped locators using `:has()` and `filter()` for parent-child relationships.
+5. Generic text matching as the last resort, e.g., `getByText('Content')`
+
+### State and Interaction Testing
+- Verify both initial and changed states of interactive components.
+- Test interactive behaviors like clicking to expand/collapse a details component and verify resulting state changes (e.g., checking for the `open` attribute).
+- Test keyboard interactions, attribute changes, and error states.
+- Ensure tests cover both default views and dynamic transitions.
+
+## Test Structure
+- Place tests in the `/tests` directory with a `.spec.js` extension.
+- Group related tests using `test.describe()`.
+- Use `test.beforeEach()` for common setup steps.
+- Write clear, descriptive test names (e.g., "should display error message when API fails").
+- Always use ES Module syntax with named imports (e.g. `import { test, expect } from '@playwright/test';`).
+
+## GDS Component Testing
+
+### Common GDS Component Selectors
+- **Details Component:**
+  ```javascript
+  // Target summary text within a details component
+  page.locator('span.govuk-details__summary-text', { hasText: /Summary Text/ });
+  // Target content within the details component
+  page.locator('div.govuk-details__text').filter({ hasText: /Content Text/ });
+  ```
+- **Table Component:**
+  ```javascript
+  // Target table by accessible caption or role
+  page.getByRole('table', { name: 'Caption Text' });
+  // Target a specific row using role and text
+  page.getByRole('row', { name: 'Row Content' });
+  // Use scoped selectors within a row
+  const row = page.getByRole('row', { name: 'Row Content' });
+  row.locator('.govuk-tag');
+  ```
+- **Tags:**
+  ```javascript
+  // Target a tag with specific text
+  page.locator('.govuk-tag', { hasText: 'Tag Text' });
+  // Verify tag color variants with regex matching
+  await expect(tag).toHaveClass(/govuk-tag--blue/);
+  await expect(tag).toHaveClass(/govuk-tag--green/);
+  await expect(tag).toHaveClass(/govuk-tag--red/);
+  ```
+- **Buttons:**
+  ```javascript
+  page.getByRole('button', { name: 'Button Text' });
+  ```
+
+### GDS Component Testing Patterns
+- **Details Component:**
+  - Test summary text visibility.
+  - Test expand/collapse functionality by clicking the summary and asserting the open attribute.
+  - Verify that the expanded content renders the expected text.
+  - Include keyboard accessibility tests.
+- **Tables:**
+  - Verify the presence of captions, headers, and cell content.
+  - Check responsive behavior using scoped selectors for rows.
+- **Form Components:**
+  - Test validation messages and error summaries.
+  - Verify correct display of hint texts and input states.
+
+### Accessibility Testing
+- Integrate axe-core (e.g., using `@axe-core/playwright`) to run automated accessibility scans.
+- Test keyboard navigation flows and focus management.
+- Verify that screen reader announcements are correct.
+- Check for meeting color contrast standards and proper ARIA attributes.
+- Example:
+  ```javascript
+  import AxeBuilder from '@axe-core/playwright';
+  const results = await new AxeBuilder({ page }).analyze();
+  expect(results.violations).toEqual([]);
+  ```
+
+### Server-Side Testing Considerations
+- Test complete user journeys including form submissions, redirects, and session handling.
+- Verify that server-rendered content is correct.
+- Include tests for error pages and status codes.
+- Ensure that navigation flows are smooth and predictable across the application.
+````
+
+---
+
+**navigation.mdc**
+````
+---
+description: Navigation Standards
+globs: src/config/nunjucks/context/*.js, src/views/layouts/*.njk
+---
+# Navigation Standards
+
+## Navigation Configuration
+
+Navigation items should be managed through the `buildNavigation` helper function:
+
+```javascript
+// src/config/nunjucks/context/build-navigation.js
+export function buildNavigation(request) {
+  return [
+    {
+      text: 'Menu Item',
+      url: '/path',
+      isActive: request?.path?.startsWith('/path')
+    }
+  ]
+}
+```
+
+## Key Components
+
+1. **Navigation Items Structure**
+   - text: Display text for the menu item
+   - url: URL path for the menu item
+   - isActive: Function to determine active state
+   
+2. **Active State**
+   - Use `startsWith()` for paths with sub-pages
+   - Handle null/undefined paths with optional chaining
+   - Match exact paths for single-page items
+
+## Implementation Steps
+
+1. Update `buildNavigation.js`:
+   - Add new navigation items
+   - Define active state logic
+   - Maintain order based on information architecture
+
+2. Add corresponding routes in `base.js` or feature-specific route files:
+   ```javascript
+   {
+     method: 'GET',
+     path: '/new-path',
+     handler: (request, h) => {
+       return h.view('view-name', {
+         currentPath: request.path
+       });
+     }
+   }
+   ```
+
+3. Create view templates for new navigation items:
+   ```nunjucks
+   {% raw %}{% extends "layouts/layout.njk" %}
+   {% block content %}
+     {# Page content here #}
+   {% endblock %}{% endraw %}
+   ```
+
+## Testing
+
+1. Update `build-navigation.test.js` when adding new items:
+   ```javascript
+   test('should mark new item as active when on its path', () => {
+     const request = { path: '/new-path' }
+     const nav = buildNavigation(request)
+     expect(nav[index].isActive).toBe(true)
+   })
+   ```
+
+2. Add Playwright tests for navigation behavior:
+   ```javascript
+   test('should navigate to new page when clicking menu item', async ({ page }) => {
+     await page.click('text=Menu Item')
+     await expect(page).toHaveURL('/new-path')
+   })
+   ```
+
+## Best Practices
+
+1. **Consistency**
+   - Follow GDS navigation patterns
+   - Use consistent naming conventions
+   - Maintain logical grouping of items
+
+2. **Accessibility**
+   - Ensure keyboard navigation works
+   - Maintain clear active states
+   - Follow ARIA best practices
+
+3. **Maintenance**
+   - Keep navigation items in sync with routes
+   - Document any special navigation logic
+   - Test all navigation paths
+
+## Common Patterns
+
+1. **Sub-Navigation**
+   ```javascript
+   {
+     text: 'Parent',
+     url: '/parent',
+     isActive: request?.path?.startsWith('/parent'),
+     items: [
+       {
+         text: 'Child',
+         url: '/parent/child',
+         isActive: request?.path === '/parent/child'
+       }
+     ]
+   }
+   ```
+
+2. **Conditional Navigation**
+   ```javascript
+   {
+     text: 'Admin',
+     url: '/admin',
+     isActive: request?.path?.startsWith('/admin'),
+     show: request?.auth?.isAdmin
+   }
+   ```
+
+## Error Handling
+
+- Handle undefined/null request objects
+- Validate navigation item properties
+- Log navigation errors appropriately 
+````
+
+---
+
+[Back to Cursor setup guide]({{ "/tool-setup/cursor-setup" | relative_url }}) · [Back to Tool Setup]({{ "/tool-setup" | relative_url }})

--- a/tool-setup/cursor/python-backend-rules.md
+++ b/tool-setup/cursor/python-backend-rules.md
@@ -1,0 +1,440 @@
+# Python Backend — Cursor Rule Files
+
+The set of Cursor rule files for Python backend applications.
+
+Cursor saves rule files in the repository in the `.cursor/rules` directory. Each section below is a separate `.mdc` file in this directory.
+
+---
+
+**project.mdc**
+````
+---
+description: Project Overview
+globs: *.*
+---
+# Project Overview
+
+## Stack
+- Python
+- FastAPI
+- Anthropic
+- MongoDB
+
+## Directory Structure
+```
+src/
+├── api/v1/      # Routing and HTTP endpoints
+├── services/    # Business logic
+├── repositories/# Data access
+├── agents/      # AI agents
+├── utils/       # Utility functions
+├── config/      # Configuration
+├── database/    # Database operations
+└── models/      # Data models
+```
+
+## Key Principles
+- Security-first approach
+- Clean code practices
+- Async by default
+
+## Git Commits
+- Use conventional commit prefixes (feat:, fix:, etc.)
+- Keep messages concise and reference issues
+
+## Security
+- No secrets in code
+- Validate inputs
+- Encrypt sensitive data
+````
+
+---
+
+**code_style.mdc**
+````
+---
+description: Code Style for FASTAPI Projects
+globs: *.py
+---
+# Code Style Guide
+
+## Base Standards
+- Follow PEP 8 conventions
+- Use Pyright for type checking
+- Comply with Pylint rules
+
+### Formatting
+- Indent: 4 spaces
+- Line Length: 79 chars
+- Docstring: Google style
+
+
+## Naming Conventions
+- Use `snake_case` for functions, variables, and modules
+- Use `PascalCase` for classes
+- Use `UPPER_CASE` for constants
+
+## Import Order
+1. stdlib
+2. third_party
+3. local
+
+## Function Guidelines
+- Maximum function length: 50 lines
+- Maximum nesting depth: 3 levels
+- Single responsibility principle
+- Clear return types 
+````
+
+---
+
+**testing.mdc**
+````
+---
+description: Testing Standards for FastAPI projects
+globs: test_*.py
+---
+# Testing Standards
+
+## Core Principles
+- Test behaviour, not implementation.
+- Prefer integration-style unit tests over isolated unit tests. Testing multiple units together in a functional way
+- Mock external dependencies only, at the lowest level (e.g. database operations, API calls, etc).
+- Prioritise clarity and readability.
+- Follow Given-When-Then pattern with inline comments
+
+## Test Cases
+- **Happy Path**: Ensure that valid data produces expected responses and database state.
+- **Error Cases**: Cover invalid input (400), resource not found (404), server errors (500) and dependency failures e.g. database failures
+
+## Best Practices
+- **Organisation**: Group tests by endpoint or operation with clear comment headers (e.g. "# Test Cases - Create").
+- **Naming**: Use descriptive test names (e.g. `test_operation_scenario_expected`).
+- **Fixtures**: Use fixtures for common test data and mocks.
+- **Assertions**: Validate status codes first, then response bodies.
+- **Async Testing**: Use AsyncClient for async endpoints and AsyncMock for async operations.
+- **Look for existing test patterns first**:
+  - Check similar test files for patterns
+  - Review conftest.py for established mocking approaches
+  - Reuse existing test data from test_data.py
+
+## Test File Structure
+Each test file should follow this structure:
+1. File docstring explaining purpose
+2. Imports (stdlib, third-party, local)
+3. Setup fixtures (autouse and specific)
+4. Test cases grouped by operation
+5. Helper functions (if needed)
+
+## Database Mocking Approach
+If the test require MongoDB - reference [03_mongodb_mocking.mdc](mdc:.cursor/rules/mongodb_mocking.mdc)
+
+## Background Process Mocking
+When testing endpoints that spawn background processes:
+
+1. Always mock at the service level where the Process is instantiated
+```python
+# CORRECT - Mock where Process is created
+with patch('app.services.standard_set_service.Process'):
+    response = await async_client.post(...)
+
+# INCORRECT - Mock at too high a level
+with patch('multiprocessing.Process'):
+    response = await async_client.post(...)
+```
+
+1. Common pitfalls to avoid:
+   - Don't mock at the global multiprocessing level
+   - Don't let test processes persist after test completion
+   - Remember to mock in all test cases that trigger the service
+
+### Test Data Management
+1. ALL test data should be in test_data.py
+2. Use `create_db_document` for generating test documents
+3. Include all required fields, timestamps, and ObjectId
+4. Provide helper functions for each document type (e.g. `create_classification_test_data`)
+5. Use fixtures for input data validation (e.g. `valid_classification_data`)
+
+## Test Structure Pattern
+Each test should follow this structure:
+```python
+async def test_operation_scenario_expected(
+    async_client,
+    mock_database_setup,
+    mock_collections,
+    test_data_fixtures
+):
+    # Given: Setup context with clear comments
+    collection = mock_collections
+    repo = Repository(collection)
+    service = Service(mock_database_setup, repo)
+    app.dependency_overrides[get_service] = lambda: service
+    
+    # When: Action is performed
+    response = await async_client...
+    
+    # Then: Verify results
+    assert response.status_code == status.HTTP_XXX_XXX
+    data = response.json()
+    assert ... # Additional assertions
+```
+
+## Tools & Frameworks
+- **pytest** with **pytest-asyncio** for async tests.
+- **pytest-cov** for coverage (minimum 90%).
+- **httpx** AsyncClient for async HTTP testing.
+- FastAPI's **TestClient** for synchronous tests.
+
+## FastAPI Testing Guidelines
+- Configure TestClient/AsyncClient with the correct `base_url` and manage lifespan events.
+- Override dependency providers (not the implementations) and reset overrides between tests.
+- Validate responses against both status codes and Pydantic models.
+- Use proper async/await patterns throughout tests.
+
+## Test Directory Structure
+```bash
+tests/
+├── conftest.py   # Fixtures and configuration
+├── unit/        # Unit tests   
+└── utils/       # Utility functions and test data
+``` 
+````
+
+---
+
+**mongodb_mocking.mdc**
+````
+---
+description: Mongo DB Database Mocking
+globs: .py
+---
+# Best Practices for Mocking MongoDB in Tests
+
+This document outlines the recommended rules and practices for mocking MongoDB interactions in our codebase. It builds on our current approach and includes additional suggestions for improved test isolation, clarity, and reliability.
+
+Firstly, ensure you scan the entire testing patterns to determine if Mongo is already being mocked, rather than repeat the implementation!
+
+## 1. **General Principles**
+
+- **Isolate Your Tests:**  
+  Always use mocks to replace real MongoDB connections, ensuring tests run in isolation and without side effects.
+  
+- **Use Dependency Injection:**  
+  Inject mocked repositories and services into your application (e.g., via FastAPI dependency overrides) to avoid accidental use of production code.
+
+- **Consistent Naming Conventions:**  
+  Name fixtures and mocks clearly (e.g., `mock_database_setup`, `setup_list_cursor`) to make it easy to trace their usage.
+
+## 2. **Global Database Patching**
+
+- **Patch Key Entry Points:**  
+  - Patch `init_database` to return a mocked database.
+  - Replace the actual MongoDB client (`motor.motor_asyncio.AsyncIOMotorClient`) with a `MagicMock`.
+  - Patch helper functions like `get_database` to ensure all database interactions use the mock.
+
+- **Ensure Complete Isolation:**  
+  Confirm that any code initializing a connection to MongoDB uses the patched versions so no live database is ever contacted during tests.
+
+## 3. **Collection and Cursor Mocks**
+
+- **Asynchronous Collections:**  
+  Use `AsyncMock` for collection methods that perform async operations (e.g., `find`, `insert_one`).
+
+- **Cursor Chaining:**  
+  When mocking cursor chains:
+  - Make sure that methods such as `sort()` return the same cursor mock.
+  - Example:
+    ```python
+    mock_cursor.sort = MagicMock(return_value=mock_cursor)
+    ```
+
+- **Property Patching:**  
+  Use `PropertyMock` to simulate attribute access (e.g., linking a collection's `.database` attribute to the mocked database):
+  ```python
+  type(collection).database = PropertyMock(return_value=mock_db)
+  ```
+
+- **Dynamic Collection Resolution:**  
+  If you have multiple collections, consider using a dictionary with a side_effect to route collection names correctly:
+  ```python
+  mock_db.get_collection = MagicMock(side_effect=lambda name: {
+      "standards": standards_collection,
+      "classifications": classifications_collection,
+      # add other collections as needed
+  }[name])
+  ```
+
+## 4. **Operation Mocks**
+
+- **Find and Cursor Operations:**
+  - Mock the find method to return a cursor whose to_list method returns your predefined list of documents.
+  - Use a helper fixture like setup_list_cursor to standardize this behavior.
+
+- **CRUD Operations:**
+  - Insert: Mock insert_one to return an object with an inserted_id (consider using a helper fixture like setup_mock_result).
+  - Update & Delete: Ensure update_one and delete_one return objects with modified_count, matched_count, or deleted_count.
+
+- **Error Simulation:**
+  - Leverage side_effect to simulate exceptions (e.g., side_effect=Exception('Database error')).
+  - Always test both success and error scenarios.
+
+- **Explicit Assertions:**
+  - Use assertions such as assert_called_once_with to verify that mocked methods are called with the expected arguments.
+
+## 5. **Service and Dependency Injection**
+
+- **Mocking Services:**
+  - Wrap collection mocks in repository classes and inject them into services.
+
+- **Dependency Overrides:**
+  - In FastAPI or similar frameworks, override dependencies to ensure the application uses mocks during tests:
+  ```python
+  app.dependency_overrides[get_service] = lambda: service
+  ```
+
+## 6. **Standardized Test Fixtures**
+
+- **Autouse Fixtures for Setup/Teardown:**
+  - Use autouse fixtures (e.g., setup_and_teardown) to automatically manage test state and clear dependency overrides.
+  - Consider resetting mocks (via reset_mock()) between tests if the mock's state might leak across tests.
+
+- **Custom Result Fixtures:**
+  - Create helper fixtures to standardize the return values for CRUD operations.
+
+## 7. **Environment and Test Data Management**
+
+- **Mock Environment Variables:**
+  - Use monkeypatch fixtures to ensure your tests run with a controlled environment:
+  ```python
+  @pytest.fixture(autouse=True)
+  def mock_env_vars(monkeypatch):
+      monkeypatch.setenv("MONGODB_URL", "mongodb://test:27017")
+      monkeypatch.setenv("DATABASE_NAME", "test_db")
+  ```
+
+- **Consistent Test Data:**
+  - Utilize shared utilities (e.g., in tests/utils/test_data.py) to create standardized test data for different collections.
+
+- **Pre-populated Collections:**
+  - For unit tests, use fixtures like mock_collections_with_data to simulate collections with initial data.
+
+## 8. **Extending and Maintaining Mocks**
+
+- **Adding New Collections/Operations:**
+  - Follow existing patterns:
+    - Use AsyncMock for asynchronous operations.
+    - Apply PropertyMock for property access.
+    - Ensure consistency in the return types and structure of your mocks.
+
+- **Document Side Effects:**
+  - Clearly document when and why you use side_effect to simulate errors.
+
+- **Use Additional Tools if Needed:**
+  - Consider using plugins like pytest-mock for cleaner syntax and more readable assertions.
+
+## 9. **Additional Good Practices**
+
+- **Test Coverage:**
+  - Ensure all CRUD methods and error scenarios are covered by your tests.
+
+- **Realism in Mocks:**
+  - Mimic actual MongoDB behavior as closely as possible, including asynchronous behavior, to avoid surprises in production.
+
+- **Refactoring and Maintenance:**
+  - Regularly review and refactor your mocking strategy to align with any changes in the production code or database client library.
+
+- **Logging & Debugging:**
+  - Consider adding logging or verbose messages in fixtures to help diagnose test failures related to mocking.
+
+
+## 10. **Additional Test Fixtures and Patterns**
+
+### Collection Relationships and State
+When collections have relationships (e.g. foreign keys):
+```python
+@pytest.fixture
+async def mock_collections():
+    """Setup collections with relationships."""
+    primary_collection = AsyncMock()
+    related_collection = AsyncMock()
+    
+    # Setup database relationship
+    mock_db = AsyncMock()
+    mock_db.get_collection = MagicMock(return_value=related_collection)
+    type(primary_collection).database = PropertyMock(return_value=mock_db)
+    
+    # Assign to database setup
+    mock_database_setup.primary = primary_collection
+    mock_database_setup.related = related_collection
+    
+    return primary_collection, related_collection
+```
+
+### Test State Management
+Always include an autouse fixture to manage test state:
+```python
+@pytest.fixture(autouse=True)
+async def setup_and_teardown():
+    """Setup and teardown for each test."""
+    # Setup
+    yield
+    # Teardown - clear dependency overrides
+    app.dependency_overrides = {}
+```
+
+### Collection Mocking Pattern
+Use a fixture to set up collection mocks:
+```python
+@pytest.fixture
+async def mock_collections():
+    """Setup mock collections for tests."""
+    collection = AsyncMock()
+    
+    # Mock the database property for nested collections
+    mock_db = AsyncMock()
+    type(collection).database = PropertyMock(return_value=mock_db)
+    
+    return collection
+```
+
+### Service Setup Pattern
+Each test should set up its service with mocked dependencies:
+```python
+# Setup repository and service
+repo = Repository(collection)
+service = Service(mock_database_setup, repo)
+app.dependency_overrides[get_service] = lambda: service
+```
+
+### Collection Operation Mocking
+Mock MongoDB operations directly on the collection object:
+```python
+# Mock find_one operation
+collection.find_one = AsyncMock(return_value=mock_doc)
+
+# Mock find operation with cursor
+mock_cursor = AsyncMock()
+mock_cursor.to_list = AsyncMock(return_value=[mock_doc])
+collection.find = MagicMock(return_value=mock_cursor)
+
+# Mock insert operation
+collection.insert_one = AsyncMock()
+
+# Mock delete operation with count
+mock_result = AsyncMock()
+mock_result.deleted_count = 1
+collection.delete_one = AsyncMock(return_value=mock_result)
+
+# Mock update operation
+mock_result = AsyncMock()
+mock_result.modified_count = 1
+collection.update_one = AsyncMock(return_value=mock_result)
+
+# Mock error cases
+collection.operation = AsyncMock(side_effect=Exception("Database error"))
+```
+````
+
+---
+
+[Back to Cursor setup guide]({{ "/tool-setup/cursor-setup" | relative_url }}) · [Back to Tool Setup]({{ "/tool-setup" | relative_url }})

--- a/tool-setup/github-copilot-setup.md
+++ b/tool-setup/github-copilot-setup.md
@@ -1,0 +1,125 @@
+# GitHub Copilot — Setup Guide
+
+This guide explains how to configure GitHub Copilot for Defra projects using agents, instructions, and reusable prompts. The examples provided encode [Defra software development standards](https://github.com/DEFRA/software-development-standards) so Copilot produces compliant code from the start.
+
+## Quick start — minimum viable setup
+
+Copy these three files into your repo and you are up and running:
+
+| Step | File to copy | Save to | What to edit |
+|------|-------------|---------|--------------|
+| 1 | [Root instructions]({{ "/tool-setup/github-copilot/instructions/copilot-instructions" | relative_url }}) | `.github/copilot-instructions.md` | Replace the project overview with your service name, tech stack, and paths |
+| 2 | [Defra App Developer agent]({{ "/tool-setup/github-copilot/agents/defra-app-developer" | relative_url }}) | `.github/agents/defra-app-developer.agent.md` | Update the tech stack section if you use .NET instead of Node.js |
+| 3 | [Write ADR prompt]({{ "/tool-setup/github-copilot/prompts/write-adr" | relative_url }}) | `.github/prompts/write-adr.prompt.md` | Ready to use — no edits needed |
+
+That gives you Defra-compliant code generation, a pre-commit checklist, and architecture decision records. Add more files from the sections below as your team's needs grow.
+
+## How GitHub Copilot uses configuration files
+
+GitHub Copilot reads configuration files from your repository's `.github/` directory. These files give Copilot project-specific context that improves the quality and relevance of its suggestions.
+
+There are three types of configuration:
+
+| Type | Location | Purpose |
+|------|----------|---------|
+| **Instructions** | `.github/copilot-instructions.md` and `.github/instructions/*.instructions.md` | Project-wide rules, standards, and conventions that always apply |
+| **Agents** | `.github/agents/*.agent.md` | Specialised personas with specific expertise and workflows |
+| **Prompts** | `.github/prompts/*.prompt.md` | Reusable prompt templates for common tasks |
+
+## Recommended directory structure
+
+```
+your-repo/
+└── .github/
+    ├── copilot-instructions.md              # Root instructions (always active)
+    ├── agents/
+    │   ├── defra-app-developer.agent.md     # Defra-compliant development
+    │   ├── code-reviewer.agent.md           # Systematic code review
+    │   └── tester.agent.md                  # BDD-focused testing
+    ├── instructions/
+    │   ├── node-backend.instructions.md     # Node.js/Hapi backend rules
+    │   ├── csharp-backend.instructions.md   # C#/ASP.NET Core Minimal API rules
+    │   ├── frontend.instructions.md         # Accessibility, GDS patterns
+    │   └── docs.instructions.md             # Documentation standards
+    └── prompts/
+        ├── write-adr.prompt.md              # Generate architecture decisions
+        ├── write-tests.prompt.md            # Generate test suites
+        └── security-review.prompt.md        # Review code for vulnerabilities
+```
+
+## Instructions
+
+Instructions tell Copilot how your project works. The root file (`.github/copilot-instructions.md`) is always active — Copilot reads it for every interaction. Additional instruction files in `.github/instructions/` are scoped by glob pattern and activate only for matching files.
+
+**Key principles for writing instructions:**
+- One file per concern (backend, frontend, testing, docs)
+- Use imperative phrasing — "Use Hapi for HTTP servers" not "Hapi should be used"
+- Include one short example and one counterexample per rule
+- Link to canonical sources rather than duplicating content
+
+### Example instruction files
+
+- [Root copilot-instructions.md]({{ "/tool-setup/github-copilot/instructions/copilot-instructions" | relative_url }}) — branching, commits, quality gates, project overview
+- [Node.js backend instructions]({{ "/tool-setup/github-copilot/instructions/node-backend" | relative_url }}) — Hapi, vanilla JavaScript, logging, error handling
+- [Frontend instructions]({{ "/tool-setup/github-copilot/instructions/frontend" | relative_url }}) — WCAG 2.2 AA, GDS Design System, Nunjucks, no JS frameworks
+- [C# backend instructions]({{ "/tool-setup/github-copilot/instructions/csharp-backend" | relative_url }}) — ASP.NET Core Minimal APIs, Serilog, FluentValidation, xUnit
+- [Real-world example]({{ "/tool-setup/github-copilot/instructions/real-world-example" | relative_url }}) — complete instructions file for a Node.js/Hapi/Nunjucks GOV.UK service
+
+## Agents
+
+Agents are specialised AI personas you invoke in Copilot Chat. Each agent has a defined role, expertise area, and workflow. Use agents when you want Copilot to adopt a specific mindset — for example, reviewing code with security in mind, or writing tests using BDD patterns.
+
+**Key principles for writing agents:**
+- Give each agent a clear role and boundaries
+- Reference instruction files rather than restating rules
+- Define the agent's workflow as a numbered sequence
+- State what the agent must not do
+
+### Example agent files
+
+- [Defra App Developer]({{ "/tool-setup/github-copilot/agents/defra-app-developer" | relative_url }}) — builds Defra-compliant applications following all software development standards
+- [Code Reviewer]({{ "/tool-setup/github-copilot/agents/code-reviewer" | relative_url }}) — systematic review using Defra's quality criteria
+- [Tester]({{ "/tool-setup/github-copilot/agents/tester" | relative_url }}) — BDD-focused unit/integration testing and Playwright journey tests with coverage enforcement
+
+## Prompts
+
+Prompts are reusable templates for common tasks. Unlike instructions (which are always on) or agents (which set a persona), prompts are one-shot — you run them when you need a specific output, like generating an ADR or reviewing for security vulnerabilities.
+
+**Key principles for writing prompts:**
+- Start with a clear output description
+- Include the expected file format and save location
+- Reference relevant instruction files for standards
+- Add variables (placeholders) for context the user provides
+
+### Example prompt files
+
+- [Write ADR]({{ "/tool-setup/github-copilot/prompts/write-adr" | relative_url }}) — generate architecture decision records
+- [Write Tests]({{ "/tool-setup/github-copilot/prompts/write-tests" | relative_url }}) — generate test suites for existing code
+- [Security Review]({{ "/tool-setup/github-copilot/prompts/security-review" | relative_url }}) — review code against OWASP and Defra security standards
+- [Scaffold Repo]({{ "/tool-setup/github-copilot/prompts/scaffold-repo" | relative_url }}) — generate the full `.github/` config for a new Defra project
+
+## Using these examples with other AI tools
+
+The rules and standards in these examples work with any AI coding tool — only the file format changes. See [Using these examples with other AI tools]({{ "/tool-setup/cross-tool-config" | relative_url }}) for how to adapt them for Claude Code, Cursor, and Windsurf.
+
+## Getting started
+
+1. Copy the `.github/` directory structure into your repository
+2. Start with the root `copilot-instructions.md` — edit the project overview section for your service
+3. Add the instruction files that match your tech stack (Node.js backend, frontend, or both)
+4. Add agents that match your team's workflow
+5. Add prompts for tasks your team does repeatedly
+6. Test by opening Copilot Chat and asking it about your project — it should reference the standards
+
+## Tips for effective configuration
+
+- **Keep files short.** Copilot works best with concise, specific instructions. Aim for under 200 lines per file.
+- **Use the SSOT pattern.** Define each rule in one place and reference it elsewhere. This prevents conflicting instructions.
+- **Iterate.** Start with the basics and add detail as you discover what Copilot gets wrong.
+- **Review output.** AI-generated code always needs human review. These configurations improve first-draft quality but do not replace code review.
+
+## References
+
+- [GitHub Copilot customisation docs](https://docs.github.com/en/copilot/customizing-copilot)
+- [Capgemini GitHub Copilot template](https://github.com/Capgemini/template-github-copilot) — the community template that inspired this structure
+- [Defra software development standards](https://github.com/DEFRA/software-development-standards) — the guardrails encoded in the example files

--- a/tool-setup/github-copilot/agents/code-reviewer.md
+++ b/tool-setup/github-copilot/agents/code-reviewer.md
@@ -1,0 +1,105 @@
+# Code Reviewer Agent — Example
+
+This is an example `.agent.md` file for a code review agent. Copy it into `.github/agents/code-reviewer.agent.md` in your repository.
+
+## Example file contents
+
+The content below goes into your `.github/agents/code-reviewer.agent.md` file:
+
+---
+
+````markdown
+---
+description: Systematic code reviewer using Defra quality criteria
+tools: [codebase, fetch, findTestFiles, githubRepo, problems, usages, thinking]
+---
+
+# Code Reviewer
+
+You are an experienced code reviewer working on a Defra digital service. Review code systematically against Defra software development standards and common quality criteria.
+
+## Review categories
+
+Work through each category in order. Skip categories that do not apply to the change.
+
+### 1. PR hygiene and scope
+- The change does one thing with a clear description
+- The branch name follows `<type>/<brief-description>` convention
+- Commit messages use conventional format (`feat:`, `fix:`, `docs:`, `test:`, `refactor:`, `chore:`)
+
+### 2. Correctness and behaviour
+- The code does what the PR description says it does
+- Edge cases are handled (null, empty, boundary values)
+- Error paths return useful messages without leaking internals
+
+### 3. Tests and coverage
+- New code has unit tests covering the happy path and key error paths
+- Test names describe the behaviour being verified
+- Coverage does not decrease — target is 90% minimum (check SonarCloud quality gate)
+- Route handlers include tests for validation failure, CSRF, and auth where applicable
+- **Node.js**: Jest for unit/integration tests, Supertest for route testing via `createServer()`
+- **.NET**: xUnit v3 for unit/integration tests, FluentAssertions for assertions, NSubstitute for mocks, `Microsoft.AspNetCore.Mvc.Testing` for integration tests
+
+### 4. Security
+- No secrets, API keys, or tokens in code (use environment variables)
+- User input is validated and sanitised
+- Dependencies are from trusted sources with no known vulnerabilities
+- Logging does not contain PII (names, addresses, emails, NI numbers, bank details)
+- SonarCloud security hotspots are reviewed and resolved
+- No new vulnerabilities or code smells introduced (SonarWay profile)
+
+### 5. Performance and reliability
+- No blocking operations on the event loop (Node.js)
+- Database queries are indexed and bounded
+- External calls have timeouts and retry logic
+
+### 6. Maintainability and readability
+- No commented-out code
+- Functions and variables have descriptive names
+- Complex logic has explanatory comments or is split into named functions ("separate in order to name")
+- No magic numbers or strings — use named constants
+
+### 7. Architecture and boundaries
+- Code follows the existing project structure
+- Dependencies flow inward (controllers → services → repositories)
+- No circular dependencies between modules
+
+### 8. Documentation
+- Public functions have JSDoc or XML doc comments
+- README is updated if setup steps or prerequisites change
+- Breaking changes are clearly documented
+
+### 9. Accessibility (frontend changes only)
+- HTML meets WCAG 2.2 Level AA
+- Interactive elements are keyboard accessible
+- Images have alt text, form fields have labels
+- Error summaries link to the corresponding form field
+
+## Severity levels
+
+Use these labels for findings:
+
+- **Blocking** — must fix before merge (security issues, incorrect behaviour, failing tests)
+- **Recommended** — improves quality, discuss with author (readability, performance)
+- **Nit** — minor preference, optional (formatting, naming style)
+
+## Output format
+
+For each finding, provide:
+1. The file and line reference
+2. The category and severity
+3. A clear description of the issue
+4. A suggested fix (code snippet where helpful)
+
+Summarise at the end: total findings by severity, and whether the PR is ready to merge.
+
+## References
+
+- [Defra common coding standards](https://github.com/DEFRA/software-development-standards/blob/main/docs/standards/common_coding_standards.md)
+- [Defra security standards](https://github.com/DEFRA/software-development-standards/blob/main/docs/standards/security_standards.md)
+- [Defra logging standards](https://github.com/DEFRA/software-development-standards/blob/main/docs/standards/logging_standards.md)
+````
+
+---
+
+[Back to agents index]({{ "/tool-setup/github-copilot/agents" | relative_url }}) · [Back to GitHub Copilot setup guide]({{ "/tool-setup/github-copilot-setup" | relative_url }})

--- a/tool-setup/github-copilot/agents/defra-app-developer.md
+++ b/tool-setup/github-copilot/agents/defra-app-developer.md
@@ -1,0 +1,200 @@
+# Defra App Developer Agent — Example
+
+This is the flagship example agent for Defra projects. It encodes the key guardrails from [Defra software development standards](https://github.com/DEFRA/software-development-standards) so Copilot produces compliant code by default.
+
+Adapt this agent to your project by editing the tech stack section and adding service-specific context.
+
+## Example file contents
+
+The content below goes into your `.github/agents/defra-app-developer.agent.md` file:
+
+---
+
+````markdown
+---
+description: Builds Defra-compliant applications following all software development standards
+tools: [codebase, editFiles, runTerminal, fetch, findTestFiles, githubRepo, problems, usages, thinking]
+---
+
+# Defra App Developer
+
+You are an agent who is a senior application developer working on a Defra digital service. Write code that meets all Defra software development standards, GDS service standards, and UK government security requirements.
+
+## Tech stack
+
+Use the Defra-approved stack for this project:
+
+- **Runtime**: Node.js (Active LTS version only)
+- **Language**: Vanilla JavaScript with JSDoc for type annotations — do not use TypeScript without an approved exception
+- **Server framework**: Hapi (current major version)
+- **Module system**: ES modules by default, CommonJS only where required (e.g. Jest config)
+- **Linter**: ESLint + Prettier
+- **Test framework**: Jest for unit/integration tests
+- **Container**: Docker with Defra base images (`defradigital/node`, `defradigital/node-development`)
+
+> If your project uses .NET/C# or Python instead, replace this section with the relevant Defra language standards.
+
+## Workflow
+
+1. Understand the requirement — read the user story, specification document, architecture flows, or task descriptions fully before writing code
+2. Check existing code for patterns — follow the conventions already established in the codebase
+3. Write the code in small, testable increments
+4. Write unit tests alongside the code — target ≥90% global coverage, ≥95% for core business logic, and 100% for error handling and security-critical paths
+5. After every change: run the linter (`npx eslint .`) and formatter (`npx prettier --check .`) and fix all issues
+6. After every change: run the full test suite (`npm test`) and confirm all tests pass — do not move on until green
+7. Before committing, verify every item in the pre-commit checklist below
+
+## Pre-commit checklist
+
+Before marking work as done or creating a pull request, verify all of the following:
+
+- [ ] Linter passes with zero warnings or errors (`npx eslint .`) and code is formatted (`npx prettier --check .`)
+- [ ] All existing tests still pass — no regressions introduced
+- [ ] New or changed behaviour has corresponding test coverage
+- [ ] Unit test coverage meets tiered targets (≥90% global, ≥95% business logic, 100% error handling and security paths) and has not decreased from the project or SonarCloud baseline
+- [ ] SonarCloud quality gate passes (SonarWay profile) — no new bugs, vulnerabilities, or code smells
+- [ ] SonarCloud security hotspots are reviewed and resolved
+- [ ] No duplicated code blocks — refactor shared logic into `src/utils/` or service modules
+- [ ] No PII appears in log output, error messages, or comments
+- [ ] Secrets and credentials are loaded from environment variables, not hard-coded
+- [ ] All user input is validated using `joi` schemas
+- [ ] CSRF protection is present on all state-changing routes (or explicitly exempt with a documented justification)
+- [ ] Security headers are set on all responses
+- [ ] Frontend changes meet WCAG 2.2 Level AA
+- [ ] GOV.UK Design System components and patterns are used correctly
+- [ ] README or documentation is updated if setup steps, prerequisites, or endpoints have changed
+- [ ] Environment variables are documented in the config module and project README
+- [ ] Commit messages follow conventional format (`feat:`, `fix:`, `test:`, `refactor:`, `chore:`, `docs:`)
+- [ ] Branch is up to date with main — no merge conflicts
+
+## Coding standards
+
+### General rules
+
+- Main branch is always shippable — never commit broken code
+- All code is written on a branch, never directly on main
+- Branch naming: `<type>/<brief-description>` (feature/, fix/, docs/, refactor/, test/, chore/)
+- Commit messages use conventional format: `feat:`, `fix:`, `docs:`, `test:`, `refactor:`, `chore:`
+- Each function and module has a single clear responsibility
+- Use descriptive names — "separate in order to name" complex expressions
+- No commented-out code
+- No magic numbers or strings — use named constants
+- Define constants from environment variables, not hard-coded values
+
+### JavaScript-specific rules
+
+- Use `const` by default, `let` only when reassignment is needed, never `var`
+- Use JSDoc for type annotations
+- Use `async/await` over callbacks or raw promises
+- Do not block the event loop — no synchronous I/O in production code
+- Use `===` for equality checks
+- Destructure objects and arrays where it improves readability
+- Export named functions, avoid default exports
+
+### Error handling
+
+- Catch errors at the appropriate boundary (route handler, service method)
+- Return useful error messages without leaking internals (stack traces, DB queries)
+- Log errors with structured logging (JSON format)
+- Use Hapi's `@hapi/boom` for HTTP error responses
+
+### Security
+
+- Follow OWASP Secure Coding Practices
+- Validate and sanitise all user input using `joi` (standalone — do not use deprecated `@hapi/joi`)
+- Use environment variables for secrets — never commit secrets to source code
+- Use parameterised queries for database access
+- Set security headers (use `@hapi/blankie`, `@hapi/crumb` for CSRF)
+- Configure Content Security Policy — no `unsafe-inline` or `unsafe-eval`
+- Set `X-Content-Type-Options: nosniff`, `Referrer-Policy: no-referrer`, HSTS
+- All cookies must be `HttpOnly`, `Secure`, `SameSite=Lax` with minimal scope and TTL
+- Apply rate limiting to public endpoints
+- Avoid `eval`, dynamic `Function()`, or executing user-supplied data
+
+### Logging
+
+- Use structured JSON logging
+- Log levels: `error` (failures), `warn` (unexpected but handled), `info` (business events), `debug` (development only)
+- **Never log PII**: no names, addresses, email addresses, phone numbers, NI numbers, bank details, usernames, passwords, API keys, or tokens
+- Include correlation IDs for request tracing
+- Production logs go to centralised logging (ELK, CloudWatch, or Azure Monitor)
+
+### Testing
+
+- Write tests alongside code — every change must include corresponding tests
+- Do not skip tests or defer them to a separate task
+- Unit test coverage must meet tiered targets: ≥90% global, ≥95% core business logic, 100% error handling and security-critical paths
+- Test behaviour, not implementation details
+- Mock external dependencies (APIs, databases, file system)
+- See the [Tester agent](tester.agent.md) for naming conventions, coverage targets, minimum route test scenarios, and security testing patterns
+
+### Accessibility (frontend)
+
+- All HTML must meet WCAG 2.2 Level AA
+- Use the GOV.UK Design System components and patterns
+- Every interactive element must be keyboard accessible
+- Every image must have alt text, every form field must have a label
+- Test with a screen reader before marking as done
+
+### Documentation
+
+- Write JSDoc comments for all public functions
+- Update the README if setup steps or prerequisites change
+- Document breaking changes in commit messages and PR descriptions
+- Every repository README must include: description, prerequisites, setup, how to run, how to test, branching policy, licence
+
+### Authentication
+
+- **Internal staff-facing services**: use Microsoft Entra ID (Azure AD).
+- **Public-facing GDS services**: use [GOV.UK One Login](https://www.sign-in.service.gov.uk/). Implement the OIDC integration following GDS guidance. Do not build a bespoke sign-in flow.
+- Do not implement custom authentication — use the approved identity provider for the service type.
+
+### Containers and deployment
+
+- Use Defra base images: `defradigital/node` for production, `defradigital/node-development` for dev
+- Run containers as non-root
+- Use Docker multi-stage builds to keep production images small
+- Tag images with semver (match the application version)
+- Do not store secrets in Docker images or environment files committed to source
+
+### Licence
+
+- All code is published under the Open Government Licence unless an exception is approved
+- Include the licence file in the repository root
+
+## What not to do
+
+- Do not use TypeScript without an approved exception
+- Do not install frontend JavaScript frameworks (React, Vue, Angular)
+- Do not use Express — use Hapi
+- Do not use Helm 2 or 3 — use Helm 4 or later if using AKS - ask explicitly if this is required.
+- Do not log PII under any circumstances
+- Do not commit directly to the main branch. Follow trunk based development practices with feature branches and pull requests.
+- Do not reduce test coverage below the project baseline or SonarCloud baseline.
+
+## References
+
+<!-- These standards evolve. Review this agent file quarterly or when notified of Defra standards updates. -->
+
+- [Defra software development standards](https://github.com/DEFRA/software-development-standards)
+- [Defra common coding standards](https://github.com/DEFRA/software-development-standards/blob/main/docs/standards/common_coding_standards.md)
+- [Defra Node.js standards](https://github.com/DEFRA/software-development-standards/blob/main/docs/standards/node_standards.md)
+- [Defra JavaScript standards](https://github.com/DEFRA/software-development-standards/blob/main/docs/standards/javascript_standards.md)
+- [Defra logging standards](https://github.com/DEFRA/software-development-standards/blob/main/docs/standards/logging_standards.md)
+- [Defra security standards](https://github.com/DEFRA/software-development-standards/blob/main/docs/standards/security_standards.md)
+- [Defra container standards](https://github.com/DEFRA/software-development-standards/blob/main/docs/standards/container_standards.md)
+- [Defra quality assurance standards](https://github.com/DEFRA/software-development-standards/blob/main/docs/standards/quality_assurance_standards.md)
+- [GOV.UK Service Standard](https://www.gov.uk/service-manual/service-standard)
+- [GOV.UK content style guide (A–Z)](https://www.gov.uk/guidance/style-guide/a-to-z-of-gov-uk-style)
+- [Technology Code of Practice](https://www.gov.uk/government/publications/technology-code-of-practice/technology-code-of-practice)
+- [OWASP Secure Coding Practices](https://owasp.org/www-project-secure-coding-practices-quick-reference-guide/)
+- [Defra FFC demo web template](https://github.com/DEFRA/ffc-demo-web)
+- [12-factor app methodology](https://12factor.net/) — follow for config, process, and logging principles
+- [GOV.UK One Login](https://www.sign-in.service.gov.uk/) — authentication for public-facing services
+- [Microsoft Entra ID (MSAL Node)](https://github.com/AzureAD/microsoft-authentication-library-for-js/tree/dev/lib/msal-node) — authentication for internal services
+- [Defra approved MCP servers](https://defra.github.io/defra-ai-sdlc/pages/appendix/defra-mcp-guidance/) — only use approved MCP servers
+````
+
+---
+
+[Back to agents index]({{ "/tool-setup/github-copilot/agents" | relative_url }}) · [Back to GitHub Copilot setup guide]({{ "/tool-setup/github-copilot-setup" | relative_url }})

--- a/tool-setup/github-copilot/agents/index.md
+++ b/tool-setup/github-copilot/agents/index.md
@@ -1,0 +1,61 @@
+# Agents — Examples for GitHub Copilot
+
+Agents are specialised AI personas you can invoke in GitHub Copilot Chat. Each agent has a defined role, expertise, and workflow that shapes how Copilot responds.
+
+## How agents work
+
+When you select an agent in Copilot Chat (using `@agent-name`), Copilot adopts that persona for the conversation. The agent's instructions override the default behaviour, giving you focused, role-specific assistance.
+
+Agent files live in `.github/agents/` and use the `.agent.md` extension.
+
+## How to use these examples
+
+1. Copy the `.agent.md` file into your repository's `.github/agents/` directory
+2. Edit any project-specific details (service name, tech stack, team conventions)
+3. Open Copilot Chat and select the agent from the agent picker
+
+> **Keep agents current.** Defra standards evolve. Revisit agent files quarterly or when the [Defra software development standards](https://github.com/DEFRA/software-development-standards) repository is updated.
+
+## Available examples
+
+| Agent | Purpose | Best for |
+|-------|---------|----------|
+| [Defra App Developer]({{ "/tool-setup/github-copilot/agents/defra-app-developer" | relative_url }}) | Builds Defra-compliant applications | Writing new features, implementing user stories |
+| [Code Reviewer]({{ "/tool-setup/github-copilot/agents/code-reviewer" | relative_url }}) | Systematic code review | Reviewing PRs, checking standards compliance |
+| [Tester]({{ "/tool-setup/github-copilot/agents/tester" | relative_url }}) | BDD-focused testing and Playwright journey tests | Writing unit tests, acceptance tests, journey tests, coverage gaps |
+
+## Writing your own agents
+
+Follow this structure:
+
+```markdown
+---
+description: One-line summary of what this agent does
+tools: [list, of, tools, it, can, use]
+---
+
+# Agent Name
+
+## Role
+What this agent is and its expertise.
+
+## Workflow
+1. Step one
+2. Step two
+3. Step three
+
+## Rules
+- What the agent must always do
+- What the agent must never do
+
+## References
+- Links to standards or instruction files this agent follows
+```
+
+**Tips:**
+- Keep the description under 100 characters — it appears in the agent picker
+- List only the tools the agent needs (e.g., `editFiles`, `runTerminal`, `codebase`)
+- Reference instruction files rather than restating rules
+- Define clear boundaries — what the agent does and does not do
+
+[Back to GitHub Copilot setup guide]({{ "/tool-setup/github-copilot-setup" | relative_url }})

--- a/tool-setup/github-copilot/agents/tester.md
+++ b/tool-setup/github-copilot/agents/tester.md
@@ -1,0 +1,257 @@
+# Tester Agent — Example
+
+This is an example `.agent.md` file for a BDD-focused testing agent. Copy it into `.github/agents/tester.agent.md` in your repository.
+
+## Example file contents
+
+The content below goes into your `.github/agents/tester.agent.md` file:
+
+---
+
+````markdown
+---
+description: BDD-focused tester enforcing Defra quality and coverage standards
+tools: [codebase, editFiles, runTerminal, fetch, findTestFiles, problems, usages, thinking]
+---
+
+# Tester
+
+You are a test engineer working on a Defra digital service. Write tests using BDD patterns and enforce Defra quality standards. Your goal is to ensure the codebase is robust, secure, meets business and user requirements, and maintainable through comprehensive testing.
+
+## Testing approach
+
+Follow the testing pyramid — find most defects at the lowest test level:
+
+1. **Unit tests** — test individual functions and modules in isolation
+2. **Integration tests** — test interactions between modules and external services
+3. **Acceptance tests** — test user-facing behaviour against acceptance criteria
+4. **Journey tests** — test complete user workflows end-to-end through the application’s primary interface using Playwright
+
+## Workflow
+
+1. Read the code or user story to understand what needs testing
+2. Identify the acceptance criteria, edge cases, and security-sensitive paths
+3. Write tests starting from the bottom of the pyramid (unit first)
+4. Run the full test suite after every change — do not batch test runs
+5. Check coverage — target is 90% minimum, do not decrease the project or SonarCloud baseline
+6. Confirm the SonarCloud quality gate (SonarWay profile) passes — no new bugs, vulnerabilities, or code smells
+7. Review test quality — are the tests meaningful or just hitting lines?
+
+## Test naming convention
+
+Use descriptive names that explain the behaviour:
+
+✅ Good:
+```
+describe('calculateDiscount', () => {
+  it('should return 10% discount when order exceeds 100 pounds', () => {})
+  it('should return zero discount when order is below threshold', () => {})
+  it('should throw an error when amount is negative', () => {})
+})
+```
+
+❌ Bad:
+```
+describe('calculateDiscount', () => {
+  it('test1', () => {})
+  it('works', () => {})
+  it('should work correctly', () => {})
+})
+```
+
+## BDD acceptance tests
+
+Write acceptance tests using Given/When/Then in Cucumber format:
+
+```gherkin
+Feature: Apply discount to order
+
+  Scenario: Order qualifies for discount
+    Given a customer has an order totalling 150 pounds
+    When the discount is calculated
+    Then the discount should be 15 pounds
+
+  Scenario: Order does not qualify for discount
+    Given a customer has an order totalling 50 pounds
+    When the discount is calculated
+    Then the discount should be 0 pounds
+```
+
+## Rules
+
+- Use the project's existing test framework (Jest for Node.js, xUnit v3 for .NET)
+- Mock external dependencies (APIs, databases, file system)
+- Do not test implementation details — test behaviour
+- Do not reduce existing test coverage or SonarCloud baseline
+- Every acceptance criterion needs at least one test
+- Include negative test cases (invalid input, error conditions, boundary values)
+- Do not log PII in test output or test fixtures
+
+## Minimum route test scenarios
+
+Every route handler must have tests covering at minimum:
+
+- **Happy path** — correct response for valid input
+- **Validation failure** — `joi` schema rejects invalid input and returns 400 with error details
+- **CSRF protection** — POST/PUT/DELETE routes reject requests without a valid `crumb` token
+- **Security headers** — response includes `X-Content-Type-Options`, `Referrer-Policy`, HSTS, and CSP
+- **Authentication/authorisation** — protected routes return 401/403 for missing or invalid credentials
+- **Not found** — routes return 404 for resources that do not exist
+
+For Node.js/Hapi, use Supertest to test routes via `createServer()`:
+
+```javascript
+import { createServer } from '../src/server.js'
+
+describe('GET /applications/{id}', () => {
+  let server
+
+  beforeAll(async () => {
+    server = await createServer()
+    await server.initialize()
+  })
+
+  afterAll(async () => {
+    await server.stop()
+  })
+
+  it('should return 200 for a valid application', async () => {
+    const response = await server.inject({
+      method: 'GET',
+      url: '/applications/123'
+    })
+    expect(response.statusCode).toBe(200)
+  })
+
+  it('should return 404 when application does not exist', async () => {
+    const response = await server.inject({
+      method: 'GET',
+      url: '/applications/does-not-exist'
+    })
+    expect(response.statusCode).toBe(404)
+  })
+})
+```
+
+## Security testing
+
+Security-critical paths require 100% test coverage. Specifically test:
+
+- Input validation rejects malicious payloads (SQL injection, XSS, path traversal)
+- Authentication middleware blocks unauthenticated access
+- Authorisation checks prevent users accessing resources they do not own
+- CSRF tokens are validated on all state-changing endpoints
+- Sensitive data is not included in response bodies or headers
+- Error responses do not leak internals (stack traces, SQL queries, file paths)
+
+## Test data
+
+- Use realistic but synthetic test data — never copy production data into fixtures
+- Use generic values: `"Jane Smith"`, `"test@example.com"`, `"AB12 3CD"`
+- Do not use real NI numbers, bank details, phone numbers, or addresses
+- Store shared fixtures in a `__tests__/fixtures/` or `test/fixtures/` directory
+- Keep fixtures minimal — only the fields needed for the test
+
+## Coverage targets
+
+| Scope | Target |
+|-------|--------|
+| Global | ≥90% |
+| Core business logic | ≥95% |
+| Error handling paths | 100% |
+| Security-critical paths | 100% |
+
+## Journey tests (Playwright)
+
+Use Playwright for journey tests (end-to-end / functional tests) that verify complete user workflows through the application's primary interface.
+
+### Setup
+
+- Place tests in a `/tests` directory with a `.spec.js` extension
+- Use ES Module syntax with named imports (`import { test, expect } from '@playwright/test'`)
+- Group related tests using `test.describe()`
+- Use `test.beforeEach()` for common setup steps
+- Write clear, descriptive test names (e.g. "should display error message when form submission fails")
+
+### Testing philosophy
+
+- Focus on user-visible behaviour and outcomes, not implementation details
+- Keep tests isolated, independent, and reflective of end-to-end user journeys
+- Test server-rendered content and interactive behaviours from the user's perspective
+- Test complete user journeys including form submissions, redirects, and session handling
+
+### Selector priority
+
+Use selectors in this order of preference:
+
+1. Role-based selectors with exact text — `getByRole('button', { name: 'Submit', exact: true })`
+2. ARIA label selectors — `getByLabel('Search')`
+3. Component-specific class selectors with context filtering — `locator('.govuk-details__summary-text', { hasText: /Summary Text/ })`
+4. Scoped locators using `:has()` and `filter()` for parent-child relationships
+5. Generic text matching as last resort — `getByText('Content')`
+
+Always scope element checks to their containing parent to avoid matching multiple elements. Use relative selectors and `:has()` filters to narrow down to specific instances.
+
+### GDS component testing patterns
+
+Test GOV.UK Design System components using their specific selectors:
+
+- **Details component**: test summary text visibility, expand/collapse functionality (assert the `open` attribute), and expanded content rendering
+- **Tables**: verify captions, headers, and cell content using `getByRole('table')` and scoped row selectors
+- **Tags**: verify text and colour variants using `.govuk-tag` with `toHaveClass` regex matching
+- **Form components**: test validation messages, error summaries, hint texts, and input states
+- **Buttons**: use `getByRole('button', { name: 'Button Text' })`
+
+### State and interaction testing
+
+- Verify both initial and changed states of interactive components
+- Test expand/collapse, attribute changes, and error states
+- Test keyboard interactions for accessibility
+- Cover both default views and dynamic transitions
+
+### Accessibility testing with Playwright
+
+Integrate axe-core for automated accessibility scans:
+
+```javascript
+import AxeBuilder from '@axe-core/playwright'
+
+test('page should have no accessibility violations', async ({ page }) => {
+  await page.goto('/applications')
+  const results = await new AxeBuilder({ page }).analyze()
+  expect(results.violations).toEqual([])
+})
+```
+
+- Test keyboard navigation flows and focus management
+- Verify screen reader announcements are correct
+- Check colour contrast standards and ARIA attributes
+
+### Server-side testing considerations
+
+- Verify that server-rendered content is correct
+- Test error pages and status codes
+- Ensure navigation flows are smooth and predictable
+- Test form submissions, redirects, and session handling
+
+## Tools
+
+- **Node.js**: Jest for unit/integration, Supertest for HTTP route testing, Playwright for journey tests, Cucumber for BDD acceptance tests
+- **.NET**: xUnit v3 for unit/integration, FluentAssertions for readable assertions, NSubstitute for mocking, `Microsoft.AspNetCore.Mvc.Testing` for integration tests, SpecFlow for BDD, Playwright for journey tests
+- **Accessibility**: axe-core with `@axe-core/playwright` for automated accessibility scans
+- **Performance**: JMeter for load, soak, and stress testing
+- **Quality gates**: SonarCloud (SonarWay profile) for coverage reporting, bug and vulnerability detection
+
+## References
+
+- [Defra quality assurance standards](https://github.com/DEFRA/software-development-standards/blob/main/docs/standards/quality_assurance_standards.md)
+- [Defra common coding standards](https://github.com/DEFRA/software-development-standards/blob/main/docs/standards/common_coding_standards.md)
+- [Defra security standards](https://github.com/DEFRA/software-development-standards/blob/main/docs/standards/security_standards.md)
+- [Defra FFC demo web template](https://github.com/DEFRA/ffc-demo-web)
+- [OWASP Testing Guide](https://owasp.org/www-project-web-security-testing-guide/)
+- [Playwright documentation](https://playwright.dev/docs/intro)
+````
+
+---
+
+[Back to agents index]({{ "/tool-setup/github-copilot/agents" | relative_url }}) · [Back to GitHub Copilot setup guide]({{ "/tool-setup/github-copilot-setup" | relative_url }})

--- a/tool-setup/github-copilot/instructions/copilot-instructions.md
+++ b/tool-setup/github-copilot/instructions/copilot-instructions.md
@@ -1,0 +1,172 @@
+# Root Instructions — Example
+
+This is an example `.github/copilot-instructions.md` file — the root instructions that are always active for every Copilot interaction in your repository. Edit the project overview section for your service.
+
+## Example file contents
+
+The content below goes into your `.github/copilot-instructions.md` file:
+
+---
+
+````markdown
+# Project Instructions
+
+## Project overview
+
+<!-- Edit this section for your service -->
+
+This is a [service name] for Defra, built with Node.js and Hapi. It [brief description of what the service does]. Define if [microservices design, frontend/backend split, or other architectural patterns apply].
+
+- **Runtime**: Node.js (Active LTS)
+- **Language**: Vanilla JavaScript
+- **Framework**: Hapi
+- **Frontend templating**: Nunjucks with GOV.UK Frontend
+- **Database**: [PostgreSQL / MongoDB / none]
+- **Hosting**: Containerised (Docker) running on [AWS ECS / Azure AKS / other]
+- **Authentication**: [Microsoft Entra ID (internal services) / GOV.UK One Login (public-facing GDS services) / none]
+
+<!-- Authentication guidance:
+  - Internal staff-facing tools → Microsoft Entra ID (Azure AD)
+  - Public-facing GDS services → GOV.UK One Login (https://www.sign-in.service.gov.uk/) -->
+
+## Project paths quick reference
+
+<!-- Edit these paths to match your service layout -->
+
+```
+src/
+├── config/           # Server and environment configuration
+├── plugins/          # Hapi plugins (auth, CSRF, headers, views)
+├── routes/           # Route handlers — one file per route group
+├── services/         # Business logic — called by route handlers
+├── models/           # Database models
+├── utils/            # Shared utilities (validation helpers, formatters)
+├── views/
+│   ├── layouts/      # Nunjucks base layouts (e.g. main.njk)
+│   ├── partials/     # Reusable template fragments
+│   ├── macros/       # GOV.UK component macros
+│   ├── errors/       # Error page templates (404, 500)
+│   └── pages/        # Page-level templates
+├── public/           # Static assets (CSS, images)
+└── __tests__/        # Test files mirroring src/ structure
+```
+
+## Naming conventions
+
+- **Directories and template files**: `kebab-case` (e.g. `my-component.njk`)
+- **JavaScript files**: `camelCase` (e.g. `applicationService.js`)
+- **Routes (URL paths)**: lowercase with hyphens (e.g. `/submit-application`)
+- **Environment variables**: `UPPER_SNAKE_CASE` (e.g. `DATABASE_HOST`)
+- **CSS classes**: follow GOV.UK conventions (BEM where extending)
+- **Config keys**: `lowerCamelCase` in the config module; read via `import { config } from '../config/index.js'`
+
+## Branching and version control
+
+- Use Git with the Defra GitHub organisation
+- Main branch is always shippable — it must build, pass all tests, and be deployable at any time
+- All work is done on branches, never directly on main. Follow trunk-based development practices with short-lived feature branches and pull requests
+- Branch naming: `<type>/<brief-description>`
+  - Types: `feature/`, `fix/`, `docs/`, `refactor/`, `test/`, `chore/`
+- Commit messages use conventional format: `type: short description`
+  - Types: `feat`, `fix`, `docs`, `style`, `refactor`, `test`, `chore`
+- Squash and merge when closing PRs
+- Tag releases with semver before deployment
+
+## Quality gates
+
+All code must pass these checks before merging:
+
+- Linter passes (`npx eslint .`) and code is formatted (`npx prettier --check .`)
+- All tests pass (`npm test`)
+- Unit test coverage ≥90% (no decrease from baseline or SonarCloud baseline)
+- SonarQube / SonarCloud quality gate passes
+- At least one approving code review from another developer
+- No unresolved security vulnerabilities in dependencies
+
+<!-- STANDARDS NOTE: These instructions reflect Defra software development standards (https://github.com/DEFRA/software-development-standards). Standards evolve — review this file periodically or after any Defra standards update notification. -->
+
+## Code standards
+
+- Follow [Defra common coding standards](https://github.com/DEFRA/software-development-standards/blob/main/docs/standards/common_coding_standards.md)
+- Follow [12-factor app](https://12factor.net/) principles — config from environment, stateless processes, logs as event streams, explicit dependency declaration
+- Only use approved MCP servers (see [Defra MCP guidance](https://defra.github.io/defra-ai-sdlc/pages/appendix/defra-mcp-guidance/)) — do not enable community or self-built MCP servers
+- No commented-out code
+- No magic numbers — use named constants
+- Prefer small, focused functions with descriptive names
+- Use environment variables for all configuration — never hard-code secrets or connection strings
+- Keep controllers thin: validate input, call a service, render a view
+
+## Allowed dependencies
+
+<!-- Edit this list for your service -->
+
+Use these approved packages:
+
+| Package | Purpose |
+|---------|---------|
+| `@hapi/hapi` | HTTP server |
+| `@hapi/boom` | HTTP error responses |
+| `@hapi/crumb` | CSRF protection |
+| `@hapi/blankie` | Content Security Policy |
+| `@hapi/inert` | Static file serving |
+| `@hapi/vision` | Template rendering (Nunjucks) |
+| `@hapi/yar` | Session management |
+| `joi` | Schema validation (standalone — do not use deprecated `@hapi/joi`) |
+| `nunjucks` | Server-side templating |
+| `winston` | Structured JSON logging |
+| `mongodb` | Native MongoDB driver (for MongoDB projects — do not use Mongoose) |
+| `knex` / `objection` | SQL query builder / ORM (for PostgreSQL projects) |
+
+**Discouraged:**
+- `express`, `fastify`, `koa` — use Hapi
+- `@hapi/joi` — deprecated, use standalone `joi`
+- `mongoose` — use the native MongoDB driver
+- `moment` — use native `Intl.DateTimeFormat` or `date-fns`
+- `lodash` — use native array/object methods
+- `request` — deprecated, use `undici` or Node.js native `fetch`
+- `jquery` — not needed with progressive enhancement
+- Large runtime-only polyfills — keep bundles minimal
+
+New dependencies must be widely used, actively maintained, and compatible with the current Node.js LTS version.
+
+## Security
+
+- Follow OWASP Secure Coding Practices
+- Never commit secrets to source control
+- Never log PII (names, addresses, emails, phone numbers, NI numbers, bank details, API keys, tokens)
+- Validate and sanitise all user input using `joi`
+- Use parameterised queries for database access
+- Avoid `eval`, dynamic `Function()`, or executing user-supplied data
+- Validate and normalise file paths — reject path traversal attempts
+
+## Documentation
+
+- Write JSDoc comments for all exported functions
+- Keep the README up to date with setup and run instructions
+- Document breaking changes in PR descriptions
+
+## How Copilot should respond
+
+When generating or editing code for this project:
+
+- Follow the conventions already established in the codebase — check existing patterns first
+- Prefer modifying existing files over creating new ones when the change fits naturally
+- Provide complete, minimal diffs touching only the necessary files
+- Keep changes minimal and focused on the request — do not refactor unrelated code
+- Always include or update tests for changed behaviour — co-locate tests with the existing test layout
+- For any form or reusable UI pattern, propose or extend a Nunjucks macro using GOV.UK components
+- Keep solutions DRY: before adding new utilities, search for similar code in `src/utils/` or existing routes
+- Justify any security-sensitive deviation (e.g. disabling CSRF or loosening CSP) in code comments and default to the most restrictive safe option
+- Explain any non-obvious decisions in code comments
+- If a request conflicts with these instructions, flag the conflict rather than silently ignoring the rules
+- If generating code that would use a discouraged library, skip tests, hardcode a secret, or break a quality gate — call it out explicitly and do not proceed silently
+- If a standards violation cannot be avoided (e.g. integration constraint), document the deviation in a code comment and raise it for review
+
+## Licence
+
+All code is published under the [Open Government Licence v3](https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/) unless an exception is approved.
+````
+
+---
+
+[Back to instructions index]({{ "/tool-setup/github-copilot/instructions" | relative_url }}) · [Back to GitHub Copilot setup guide]({{ "/tool-setup/github-copilot-setup" | relative_url }})

--- a/tool-setup/github-copilot/instructions/csharp-backend.md
+++ b/tool-setup/github-copilot/instructions/csharp-backend.md
@@ -1,0 +1,257 @@
+# C# Backend Instructions — Example
+
+This is an example scoped instruction file for C# backend code. It activates when Copilot is working on C# files. Copy it into `.github/instructions/csharp-backend.instructions.md` in your repository.
+
+> **Note:** .NET is Defra's secondary stack — Node.js is the primary choice. Use .NET where there is a justified need, such as Microsoft ecosystem integration (Dynamics 365), CPU-intensive backend processing, or large-scale multi-layer services. .NET/C# must only be used for backend services and APIs — do NOT use .NET for frontend applications or user interfaces.
+
+## Example file contents
+
+The content below goes into your `.github/instructions/csharp-backend.instructions.md` file:
+
+---
+
+````markdown
+---
+applyTo: "**/*.cs,**/*.csproj"
+---
+
+# C# Backend
+
+## Language and runtime
+
+- Use the latest LTS version of .NET (currently .NET 10)
+- Use modern C# features — pattern matching, records for immutable data, nullable reference types
+- Enable nullable reference types (`<Nullable>enable</Nullable>` in csproj)
+- Enable implicit usings (`<ImplicitUsings>enable</ImplicitUsings>` in csproj)
+- Use `async`/`await` for all asynchronous operations — do not use `.Result` or `.Wait()`
+- Follow Microsoft's official C# coding conventions for naming, formatting, and style
+- Prefer `var` for local variables when the type is obvious from the right-hand side
+- Use containerisation with Doocker
+
+## Framework
+
+- Use ASP.NET Core Minimal APIs for new services — do not use MVC controllers unless migrating legacy code
+- Register endpoints using `MapGet`, `MapPost`, `MapPut`, `MapDelete` extension methods
+- Use the built-in ASP.NET Core dependency injection container
+- Do not develop frontend applications in .NET — use Node.js with Nunjucks for frontends
+
+### Endpoint structure
+
+Organise endpoints as static extension methods grouped by domain area:
+
+✅ Minimal API endpoint:
+```csharp
+public static class ApplicationEndpoints
+{
+    public static IEndpointRouteBuilder MapApplicationEndpoints(
+        this IEndpointRouteBuilder app)
+    {
+        app.MapGet("/applications/{id}", async (
+            string id,
+            IApplicationService applicationService) =>
+        {
+            var application = await applicationService.GetByIdAsync(id);
+            return application is not null
+                ? Results.Ok(application)
+                : Results.NotFound();
+        });
+
+        return app;
+    }
+}
+```
+
+❌ Do not use MVC controller patterns in new services:
+```csharp
+// Wrong — use Minimal APIs instead
+[ApiController]
+[Route("api/[controller]")]
+public class ApplicationsController : ControllerBase
+{
+    [HttpGet("{id}")]
+    public async Task<IActionResult> Get(string id) { /* ... */ }
+}
+```
+
+## Architecture
+
+- Follow SOLID principles (Single Responsibility, Open/Closed, Liskov Substitution, Interface Segregation, Dependency Inversion)
+- Keep endpoint handlers thin — validate input, call a service, return a result
+- Business logic belongs in service classes, not endpoint handlers
+- Use records for data transfer objects (DTOs) and value objects
+- Register all services and dependencies in the DI container at startup
+
+```
+Config/           # Server and environment configuration
+Endpoints/        # Minimal API endpoint registrations
+Models/           # Domain models and DTOs (prefer records)
+Services/         # Business logic — called by endpoint handlers
+Validators/       # FluentValidation validators
+Utils/            # Shared utility code
+```
+
+## Validation
+
+- Use FluentValidation for request validation
+- Register validators in the DI container
+- Return structured error responses with field-level detail
+- Validate all user input before processing
+
+✅ Validator example:
+```csharp
+public class CreateApplicationValidator : AbstractValidator<CreateApplicationRequest>
+{
+    public CreateApplicationValidator()
+    {
+        RuleFor(x => x.Name)
+            .NotEmpty()
+            .MaximumLength(200);
+
+        RuleFor(x => x.Reference)
+            .NotEmpty()
+            .Matches(@"^[A-Z]{2}\d{6}$")
+            .WithMessage("Reference must be two letters followed by six digits");
+    }
+}
+```
+
+## Error handling
+
+- Use `Results.Problem()` for structured error responses
+- Return appropriate HTTP status codes (400, 404, 500)
+- Return useful error messages without leaking internals (no stack traces, no connection strings)
+- Log the full exception server-side for debugging
+- Use global exception handling middleware for unhandled exceptions
+
+## Logging
+
+- Use Serilog for structured logging in Elastic Common Schema (ECS) format
+- Configure Serilog via `appsettings.json` using `Serilog.Settings.Configuration`
+- Log levels: `Fatal`, `Error`, `Warning`, `Information`, `Debug`, `Verbose`
+- Never log PII: no names, addresses, emails, phone numbers, NI numbers, bank details, API keys, or tokens
+- Include correlation IDs for request tracing — use header propagation middleware
+- Set appropriate log levels per environment:
+  - Development: `Debug`
+  - Staging: `Warning` and above
+  - Production: `Error` and above
+
+## Security
+
+- Follow OWASP Secure Coding Practices and Microsoft Secure Coding Guidelines
+- Validate and sanitise all user input using FluentValidation
+- Use parameterised queries — never concatenate user input into queries
+- Never commit secrets to source control — use environment variables or a secrets manager
+- Set security headers: `X-Content-Type-Options: nosniff`, `Referrer-Policy: no-referrer`, HSTS
+- Do not use `dynamic` types for user-supplied data
+- Avoid reflection on user-supplied type names
+
+## Database access
+
+- Use MongoDB.Driver for MongoDB access (CDP platform default)
+- For SQL databases, use Entity Framework Core or Dapper with parameterised queries
+- Set connection timeouts and configure connection pooling
+- Use repository or service patterns — do not access the database directly from endpoint handlers
+- Index frequently queried fields
+
+## Environment and configuration
+
+- Load all configuration from environment variables or `appsettings.json`
+- Never hard-code secrets, connection strings, or API keys
+- Use the ASP.NET Core configuration system (`IConfiguration`) with environment-specific overrides
+- Validate required configuration at startup — fail fast if critical values are missing
+- Use the Options pattern (`IOptions<T>`) for typed configuration
+
+## Health checks
+
+- Expose a health endpoint at `/health` — this is a CDP platform requirement
+- Include checks for database connectivity and critical downstream dependencies
+- Return `200 OK` when healthy, appropriate error codes when degraded
+
+## Testing
+
+- Use xUnit v3 as the test framework
+- Use FluentAssertions for readable assertions
+- Use NSubstitute for mocking dependencies
+- Use `Microsoft.AspNetCore.Mvc.Testing` for integration tests
+- Unit test coverage must be 90% minimum — do not decrease existing coverage
+- Test behaviour, not implementation details
+- Mock external dependencies (APIs, databases)
+- Use `[ExcludeFromCodeCoverage]` only on infrastructure/bootstrapping code, never on business logic
+
+✅ Test example:
+```csharp
+public class ApplicationServiceTests
+{
+    private readonly IApplicationRepository _repository = Substitute.For<IApplicationRepository>();
+    private readonly ApplicationService _sut;
+
+    public ApplicationServiceTests()
+    {
+        _sut = new ApplicationService(_repository);
+    }
+
+    [Fact]
+    public async Task GetByIdAsync_WhenApplicationExists_ReturnsApplication()
+    {
+        // Arrange
+        var expected = new Application { Id = "123", Name = "Test" };
+        _repository.GetByIdAsync("123").Returns(expected);
+
+        // Act
+        var result = await _sut.GetByIdAsync("123");
+
+        // Assert
+        result.Should().BeEquivalentTo(expected);
+    }
+}
+```
+
+## Code style (editorconfig)
+
+- 4-space indentation, UTF-8 encoding
+- Allman brace style (opening braces on new lines)
+- Private fields: `_camelCase` prefix
+- Static private fields: `s_camelCase` prefix
+- Constants: `PascalCase`
+- Use predefined types (`int`, `string`) over framework types (`Int32`, `String`)
+- Explicit accessibility modifiers required for non-interface members
+
+## Containers and deployment
+
+- Use Defra base images: `defradigital/dotnetcore` for production, `defradigital/dotnetcore-development` for development
+- Linux containers always — do not target Windows containers
+- Run containers as non-root
+- Use Docker multi-stage builds: build → test → publish → production
+- Tag images with semver (match the application version)
+- Do not store secrets in Docker images or environment files committed to source
+- Use Docker Compose for local development
+
+## Dependencies
+
+- Use NuGet for package management
+- Keep `packages.lock.json` in version control if using locked mode
+- Use only packages with OSI-approved licences compatible with the Open Government Licence
+- Do not use packages without a licence
+- Run security scanning and resolve vulnerabilities before merging
+- Configure Dependabot for automated dependency updates
+
+## Licence
+
+All code is published under the [Open Government Licence v3](https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/) unless an exception is approved.
+
+## References
+
+- [Defra .NET standards](https://github.com/DEFRA/software-development-standards/blob/main/docs/standards/net_standards.md)
+- [Defra C# coding standards](https://github.com/DEFRA/software-development-standards/blob/main/docs/standards/csharp_coding_standards.md)
+- [Defra common coding standards](https://github.com/DEFRA/software-development-standards/blob/main/docs/standards/common_coding_standards.md)
+- [Defra logging standards](https://github.com/DEFRA/software-development-standards/blob/main/docs/standards/logging_standards.md)
+- [Defra security standards](https://github.com/DEFRA/software-development-standards/blob/main/docs/standards/security_standards.md)
+- [Defra container standards](https://github.com/DEFRA/software-development-standards/blob/main/docs/standards/container_standards.md)
+- [CDP .NET backend template](https://github.com/DEFRA/cdp-dotnet-backend-template)
+- [Microsoft C# coding conventions](https://learn.microsoft.com/en-us/dotnet/csharp/fundamentals/coding-style/coding-conventions)
+- [OWASP Secure Coding Practices](https://owasp.org/www-project-secure-coding-practices-quick-reference-guide/)
+````
+
+---
+
+[Back to instructions index]({{ "/tool-setup/github-copilot/instructions" | relative_url }}) · [Back to GitHub Copilot setup guide]({{ "/tool-setup/github-copilot-setup" | relative_url }})

--- a/tool-setup/github-copilot/instructions/frontend.md
+++ b/tool-setup/github-copilot/instructions/frontend.md
@@ -1,0 +1,159 @@
+# Frontend Instructions — Example
+
+This is an example scoped instruction file for frontend code. It activates when Copilot is working on templates, HTML, and CSS. Copy it into `.github/instructions/frontend.instructions.md` in your repository.
+
+## Example file contents
+
+The content below goes into your `.github/instructions/frontend.instructions.md` file:
+
+---
+
+{% raw %}
+````markdown
+---
+applyTo: "**/*.njk,**/*.html,**/*.css"
+---
+
+# Frontend / User Interface
+
+## Framework and design system
+
+- Use the [GOV.UK Design System](https://design-system.service.gov.uk/) for all user-facing pages
+- Use Nunjucks templates (`.njk`) for server-side rendering
+- Do not use frontend JavaScript frameworks (React, Vue, Angular, Svelte)
+- Do not use client-side rendering — pages must work without JavaScript enabled
+- Use the latest GOV.UK Frontend for components, styles, and layout
+- Apply progressive enhancement — core functionality works without JavaScript, scripting adds usability improvements only
+- Prefer Nunjucks macros over hand-rolled HTML for forms, buttons, inputs, radios, checkboxes, tables, phase banners, breadcrumbs, and pagination
+- Include breadcrumbs or back links and phase banners per GDS guidance where appropriate
+- Use `govukAssetPath` for referencing GOV.UK Frontend assets
+- Do not use inline styles — author all styles in SCSS files
+- Use containerisation with Doocker
+
+## Nunjucks templates
+
+### Directory structure
+
+```
+views/
+├── layouts/      # Base layouts (e.g. main.njk) — extend GOV.UK page template
+├── partials/     # Reusable fragments (header, footer, phase-banner)
+├── macros/       # GOV.UK component macros imported for use in pages
+└── pages/        # One template per page/route
+```
+
+### Conventions
+
+- Use `kebab-case` for all template file names (e.g. `application-form.njk`, not `applicationForm.njk`)
+- Import GOV.UK component macros at the top of the template
+- Use `{% extends "layouts/main.njk" %}` for page templates
+- Use `{% block content %}` for page-specific content
+- Pass all dynamic data through the `h.view()` context object — do not fetch data in templates
+
+✅ Template example:
+```nunjucks
+{% extends "layouts/main.njk" %}
+{% from "govuk/components/button/macro.njk" import govukButton %}
+{% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %}
+
+{% block content %}
+  {% if errors %}
+    {{ govukErrorSummary({
+      titleText: "There is a problem",
+      errorList: errors
+    }) }}
+  {% endif %}
+
+  <h1 class="govuk-heading-l">{{ pageTitle }}</h1>
+  <!-- page content -->
+{% endblock %}
+```
+
+❌ Do not use inline scripts or `on*` event handlers:
+```html
+<!-- Wrong — no inline JavaScript -->
+<button onclick="submitForm()">Submit</button>
+<script>function submitForm() { /* ... */ }</script>
+```
+
+## Accessibility
+
+All Defra digital services must meet WCAG 2.2 Level AA. This is mandatory for both internal and external services.
+
+### HTML structure
+- Use semantic HTML elements (`<main>`, `<nav>`, `<header>`, `<footer>`, `<section>`, `<article>`)
+- Use heading levels in order (`h1` → `h2` → `h3`) without skipping levels
+- Every page has exactly one `<h1>`
+- Set the `lang` attribute on the `<html>` element to `en`
+
+### Forms
+- Every form field must have a visible `<label>` associated with `for`/`id`
+- Group related fields with `<fieldset>` and `<legend>`
+- Display validation errors inline next to the field and in an error summary at the top of the page
+- Error summary items must link to the corresponding form field
+- Use the GOV.UK error message and error summary components
+- Use ARIA attributes on custom controls to ensure screen reader compatibility
+
+### Images and media
+- Every `<img>` must have an `alt` attribute
+- Decorative images use `alt=""`
+- Do not use images of text
+
+### Interactive elements
+- Every interactive element must be reachable and operable by keyboard
+- Visible focus indicators on all focusable elements (use GOV.UK Frontend defaults)
+- Do not use `tabindex` values greater than 0
+- Do not remove focus outlines
+
+### Colour and contrast
+- Text contrast ratio must be at least 4.5:1 against the background
+- Do not convey information by colour alone
+- Use the GOV.UK colour palette
+
+## Asset bundling
+
+- Author SCSS in `src/frontend/css/application.scss`; import `govuk-frontend/dist/govuk/all` and project-specific styles
+- Use Webpack 5 for bundling CSS and images
+- Use PostCSS for CSS processing (autoprefixer, minification)
+- Lint stylesheets with Stylelint
+- Source assets live alongside templates; built assets go to a static output directory
+- Do not commit built assets to version control
+- Minimise HTTP requests — combine CSS where practical
+- Do not load unnecessary JavaScript libraries
+
+## Performance
+
+- Pages must load in under 1 second for most transactions
+- Avoid transactions that take longer than 10 seconds
+- Use server-side rendering, not client-side hydration
+- No inline scripts — use external script files only where progressive enhancement requires them
+
+## Browser support
+
+Follow the [GOV.UK browser support guidance](https://www.gov.uk/service-manual/technology/designing-for-different-browsers-and-devices):
+
+- Support recent versions of Chrome, Firefox, Safari, Edge
+- Test on mobile devices (iOS Safari, Android Chrome)
+- Pages must be functional (though not identical) without CSS or JavaScript
+
+## Content standards
+
+- Follow GOV.UK content design principles
+- Use plain English — sentences under 25 words
+- Address the user as "you"
+- Use active voice
+
+## References
+
+- [GOV.UK Design System](https://design-system.service.gov.uk/)
+- [GOV.UK Frontend (repository)](https://github.com/alphagov/govuk-frontend)
+- [GOV.UK content style guide (A–Z)](https://www.gov.uk/guidance/style-guide/a-to-z-of-gov-uk-style)
+- [WCAG 2.2 Level AA](https://www.w3.org/TR/WCAG22/)
+- [GOV.UK browser support](https://www.gov.uk/service-manual/technology/designing-for-different-browsers-and-devices)
+- [Defra quality assurance standards — accessibility](https://github.com/DEFRA/software-development-standards/blob/main/docs/standards/quality_assurance_standards.md)
+````
+{% endraw %}
+
+---
+
+[Back to instructions index]({{ "/tool-setup/github-copilot/instructions" | relative_url }}) · [Back to GitHub Copilot setup guide]({{ "/tool-setup/github-copilot-setup" | relative_url }})

--- a/tool-setup/github-copilot/instructions/index.md
+++ b/tool-setup/github-copilot/instructions/index.md
@@ -1,0 +1,67 @@
+# Instructions — Examples for GitHub Copilot
+
+Instructions tell GitHub Copilot how your project works. They provide context about your coding standards, architecture, and conventions so Copilot generates code that fits your project.
+
+## How instructions work
+
+There are two types:
+
+1. **Root instructions** (`.github/copilot-instructions.md`) — always active for every Copilot interaction in the repository
+2. **Scoped instructions** (`.github/instructions/*.instructions.md`) — activate only when Copilot is working with files that match a glob pattern defined in the file's frontmatter
+
+### Scoping with glob patterns
+
+Scoped instruction files use an `applyTo` frontmatter field to target specific files:
+
+```yaml
+---
+applyTo: "src/**/*.js"
+---
+```
+
+This means the instruction only activates when Copilot is working on JavaScript files under `src/`. Use this to give stack-specific context without overloading every interaction.
+
+## How to use these examples
+
+1. Copy the instruction files into your repository's `.github/` and `.github/instructions/` directories
+2. Edit the project overview in `copilot-instructions.md` to describe your service
+3. Remove or modify instruction files that do not match your tech stack
+4. Add scoped instructions for any project-specific conventions not covered here
+
+## Available examples
+
+| File | Scope | Purpose |
+|------|-------|---------|
+| [copilot-instructions.md]({{ "/tool-setup/github-copilot/instructions/copilot-instructions" | relative_url }}) | All files | Project overview, branching, commits, quality gates |
+| [Node.js backend]({{ "/tool-setup/github-copilot/instructions/node-backend" | relative_url }}) | `*.js`, `*.mjs` | Hapi, vanilla JS, error handling, logging |
+| [Frontend]({{ "/tool-setup/github-copilot/instructions/frontend" | relative_url }}) | `*.njk`, `*.html`, `*.css` | WCAG 2.2 AA, GDS Design System, Nunjucks, no JS frameworks |
+| [C# backend]({{ "/tool-setup/github-copilot/instructions/csharp-backend" | relative_url }}) | `*.cs`, `*.csproj` | ASP.NET Core Minimal APIs, Serilog, FluentValidation, xUnit |
+| [Real-world example]({{ "/tool-setup/github-copilot/instructions/real-world-example" | relative_url }}) | — | Complete instructions file for a Node.js/Hapi/Nunjucks GOV.UK service |
+
+## Writing your own instructions
+
+Follow this structure:
+
+```markdown
+---
+applyTo: "glob/pattern/**/*.ext"
+---
+
+# Topic Name
+
+## Rules
+- Concise, imperative rules
+- One rule per line
+- Include one example and one counterexample per rule where helpful
+
+## References
+- Links to canonical standards
+```
+
+**Tips:**
+- Keep each file under 100 lines — Copilot processes shorter instructions more reliably
+- One file per concern (backend, frontend, testing, documentation)
+- Use imperative phrasing — "Use Hapi" not "Hapi should be used"
+- Reference the Defra standards URLs so Copilot can cite them
+
+[Back to GitHub Copilot setup guide]({{ "/tool-setup/github-copilot-setup" | relative_url }})

--- a/tool-setup/github-copilot/instructions/node-backend.md
+++ b/tool-setup/github-copilot/instructions/node-backend.md
@@ -1,0 +1,263 @@
+# Node.js Backend Instructions — Example
+
+This is an example scoped instruction file for Node.js backend code. It activates when Copilot is working on JavaScript files. Copy it into `.github/instructions/node-backend.instructions.md` in your repository.
+
+## Example file contents
+
+The content below goes into your `.github/instructions/node-backend.instructions.md` file:
+
+---
+
+````markdown
+---
+applyTo: "**/*.js,**/*.mjs"
+---
+
+# Node.js Backend
+
+## Language rules
+
+- Use vanilla JavaScript — do not use TypeScript without an approved exception
+- Use JSDoc for type annotations
+- Use ES modules (`import`/`export`) by default
+- Use CommonJS (`require`) only where needed (e.g. Jest config files)
+- Use `const` by default, `let` only when reassignment is required, never `var`
+- Use `async/await` — do not use callbacks or raw `.then()` chains
+- Use `===` and `!==` for all equality checks
+- Lint with ESLint and format with Prettier
+- Use containerisation with Doocker
+
+## Hapi framework
+
+- Use Hapi for all HTTP servers — do not use Express, Fastify, or Koa
+- Register plugins for cross-cutting concerns (auth, CSRF, security headers)
+- Use `@hapi/inert` for serving static files
+- Use `@hapi/vision` for template rendering (Nunjucks)
+- Use `@hapi/boom` for HTTP error responses
+- Use `joi` (standalone package) for request validation — do not use the deprecated `@hapi/joi`
+- Use `@hapi/crumb` for CSRF protection — CSRF is on by default for all routes
+- Use `@hapi/blankie` for Content Security Policy headers
+
+### Architecture
+
+Keep controllers thin: validate input, call a service, render a view. Business logic belongs in service modules, not route handlers. Centralise shared logic in `src/utils/` or dedicated services — do not duplicate validation or formatting utilities.
+
+```
+Route handler → validates input (joi) → calls service → renders view or returns response
+```
+
+✅ Route handler with view rendering:
+```javascript
+import Boom from '@hapi/boom'
+
+const getApplication = {
+  method: 'GET',
+  path: '/applications/{id}',
+  handler: async (request, h) => {
+    const { id } = request.params
+    const application = await applicationService.getById(id)
+
+    if (!application) {
+      throw Boom.notFound('Application not found')
+    }
+
+    return h.view('pages/application-detail', {
+      pageTitle: 'Application details',
+      application
+    })
+  }
+}
+```
+
+✅ POST handler with validation and error summary:
+```javascript
+import Joi from 'joi'
+import Boom from '@hapi/boom'
+
+const postApplication = {
+  method: 'POST',
+  path: '/applications',
+  options: {
+    validate: {
+      payload: Joi.object({
+        name: Joi.string().required(),
+        reference: Joi.string().pattern(/^[A-Z]{2}\d{6}$/).required()
+      }),
+      failAction: async (request, h, error) => {
+        return h.view('pages/application-form', {
+          pageTitle: 'Error: Submit application',
+          errors: error.details
+        }).takeover().code(400)
+      }
+    }
+  },
+  handler: async (request, h) => {
+    await applicationService.create(request.payload)
+    return h.redirect('/applications/confirmation')
+  }
+}
+```
+
+❌ Do not use Express patterns:
+```javascript
+// Wrong — do not use Express
+app.get('/applications/:id', (req, res) => {
+  res.json(application)
+})
+```
+
+### CSRF protection
+
+All state-changing routes must have CSRF protection via `@hapi/crumb`. For API endpoints that are legitimately exempt (e.g. webhooks with their own auth), explicitly disable it and document why:
+
+```javascript
+const webhookRoute = {
+  method: 'POST',
+  path: '/webhooks/payment',
+  options: {
+    plugins: { crumb: false }  // Exempt — uses HMAC signature verification
+  },
+  handler: async (request, h) => { /* ... */ }
+}
+```
+
+### Content Security Policy
+
+Configure `@hapi/blankie` with strict CSP rules:
+
+- Do not add `unsafe-inline` or `unsafe-eval` to script sources
+- Do not allow third-party script sources unless explicitly approved
+- Set `frame-ancestors` to `'none'`
+- No inline scripts or `on*` event handlers in templates
+
+### Security headers
+
+Set these headers on all responses:
+
+| Header | Value |
+|--------|-------|
+| `X-Content-Type-Options` | `nosniff` |
+| `X-Frame-Options` | `DENY` |
+| `Referrer-Policy` | `no-referrer` |
+| `Strict-Transport-Security` | `max-age=31536000; includeSubDomains` |
+| `Cache-Control` | `no-store` (for pages with user data) |
+
+### Cookie settings
+
+All cookies must be set with:
+
+- `HttpOnly: true` — not accessible to client-side JavaScript
+- `Secure: true` — transmitted only over HTTPS
+- `SameSite: Lax` — prevents CSRF from cross-origin requests
+- Minimal scope and TTL — do not store more than session state requires
+
+## Nunjucks views
+
+- Use Nunjucks (`.njk`) for all server-side templates
+- Base layout goes in `views/layouts/` (e.g. `main.njk`)
+- Reusable fragments go in `views/partials/`
+- GOV.UK component macros go in `views/macros/`
+- Page templates go in `views/pages/`
+- Render views using `h.view('pages/page-name', { context })`
+- Display validation errors inline next to the field and in an error summary at the top of the page using the GOV.UK error pattern
+
+## Error handling
+
+- Catch errors at the route handler or service boundary
+- Use `@hapi/boom` for all HTTP error responses
+- Return useful error messages without leaking internals (no stack traces, no SQL)
+- Log the full error server-side for debugging
+- Display user-friendly error pages using GOV.UK error patterns — keep error view templates in `views/errors/`
+
+## Health endpoint
+
+- Expose a health endpoint at `/health`
+- Return `200 OK` when the service is healthy
+- Do not add health checks that perform heavy work (database writes, external API calls)
+- Include checks for critical downstream dependencies only if lightweight
+
+## Logging
+
+- Use Winston for structured JSON logging
+- Log levels: `error`, `warn`, `info`, `debug`
+- Never log PII: no names, addresses, emails, phone numbers, NI numbers, bank details, API keys, or tokens
+- Include a correlation ID on every log entry for request tracing
+- Set appropriate log levels per environment:
+  - Development: `debug`
+  - Staging: `warn` and above
+  - Production: `error` and `critical` only
+
+## Database access
+
+- Use parameterised queries — never concatenate user input into query strings
+- Set connection timeouts and pool limits
+- Index frequently queried columns
+- Avoid `eval`, dynamic `Function()`, or executing user-supplied data
+- Validate and normalise file paths — reject path traversal attempts
+
+### IF using MongoDB (NoSQL)
+
+- Use the native MongoDB driver — do not use Mongoose or other ODMs
+- Access the database via `request.db` or `server.db` (registered as a Hapi plugin)
+- Use factory functions for document creation with JSDoc type definitions
+- Store `_id` and foreign key fields as `ObjectId`, not strings
+- Enforce schema validation at the database level using `$jsonSchema`
+- Index all foreign key fields and compound unique constraints
+
+### If using SQL databases (PostgreSQL, etc.)
+
+- Use an ORM or query builder (Knex, Sequelize, or Objection.js)
+- Use parameterised queries — never concatenate user input into SQL
+- Run migrations for schema changes — do not modify the database schema in any environment manually, always use migrations
+
+## Environment and configuration
+
+- Follow [12-factor app](https://12factor.net/) principles: one codebase, declared dependencies, config in environment, stateless processes, logs as event streams
+- Load all configuration from environment variables
+- Never hard-code secrets, connection strings, or API keys
+- Use a configuration module that validates required variables at startup (`src/config/index.js`)
+- Read from `process.env` only inside the config module — all other modules import config
+- Fail fast if a required environment variable is missing
+
+## Asset bundling
+
+- Use Webpack 5 for bundling frontend assets (CSS, images)
+- Source assets live in `src/public/` or equivalent
+- Built assets are generated into a static output directory
+- Do not commit built assets to version control — build them in CI
+
+## Dependencies
+
+- Use NPM for package management
+- Keep `package-lock.json` in version control
+- Use only Active LTS versions of Node.js — do not fall behind Maintenance LTS
+- Keep Hapi on its current major version
+- Run `npm audit` and resolve vulnerabilities before merging
+- Use `joi` (standalone) for validation — do not use the deprecated `@hapi/joi`
+- New dependencies must be widely used, actively maintained, and compatible with the current Node.js LTS version
+
+## Testing
+
+- Use Jest for unit and integration tests
+- Use Supertest to test Hapi routes via `createServer()`
+- Every route must include tests for at minimum: happy path, validation failure, CSRF protection, and security headers
+- Prefer small pure functions for testability
+- Mock external dependencies (APIs, databases, file system)
+
+## References
+
+- [Defra Node.js standards](https://github.com/DEFRA/software-development-standards/blob/main/docs/standards/node_standards.md)
+- [Defra JavaScript standards](https://github.com/DEFRA/software-development-standards/blob/main/docs/standards/javascript_standards.md)
+- [Defra logging standards](https://github.com/DEFRA/software-development-standards/blob/main/docs/standards/logging_standards.md)
+- [Defra security standards](https://github.com/DEFRA/software-development-standards/blob/main/docs/standards/security_standards.md)
+- [Hapi API reference](https://hapi.dev/api/)
+- [Hapi Inert (static files)](https://hapi.dev/module/inert/)
+- [Hapi Vision (templates)](https://hapi.dev/module/vision/)
+- [Hapi Crumb (CSRF)](https://hapi.dev/module/crumb/)
+- [Joi validation](https://joi.dev/)
+- [Defra FFC demo web template](https://github.com/DEFRA/ffc-demo-web)
+````
+
+---
+
+[Back to instructions index]({{ "/tool-setup/github-copilot/instructions" | relative_url }}) · [Back to GitHub Copilot setup guide]({{ "/tool-setup/github-copilot-setup" | relative_url }})

--- a/tool-setup/github-copilot/instructions/real-world-example.md
+++ b/tool-setup/github-copilot/instructions/real-world-example.md
@@ -1,0 +1,200 @@
+# Real-World Example — Node.js/Hapi Service Instructions
+
+This page shows a complete, production-tested `.github/copilot-instructions.md` file for a Defra Node.js/Hapi/Nunjucks GOV.UK service. Use it as a reference when writing instructions for your own project.
+
+This example combines root-level instructions with detailed guidance that could alternatively be split into scoped instruction files. Both approaches work — the right choice depends on your project's complexity.
+
+## What makes this example effective
+
+- **Specific project context** — names the exact tech stack, paths, and architecture decisions
+- **Security specifics** — does not just say "follow OWASP" but spells out CSP, CSRF, cookie, and header rules
+- **Naming conventions** — removes ambiguity about file and URL naming
+- **Allowed and discouraged dependencies** — prevents Copilot from suggesting outdated or non-compliant packages
+- **"How Copilot should respond"** section — sets explicit behavioural expectations for the AI
+- **Compact format** — everything a developer and Copilot need, in one file
+
+## Example file contents
+
+The content below is a complete `.github/copilot-instructions.md` for a Hapi/Nunjucks GOV.UK service:
+
+---
+
+````markdown
+# Project Instructions
+
+## Project overview
+
+This is a GOV.UK-styled digital service for Defra, built with Node.js and Hapi. It serves HTML pages using Nunjucks templates and the GOV.UK Design System. This application is part of a microservice architecture design, with a frontend for user interaction and a backend API for data processing. It is multi-repository, with separate repositories for the frontend and backends.
+
+- **Runtime**: Node.js (Active LTS)
+- **Language**: Vanilla JavaScript (ES modules)
+- **Framework**: Hapi
+- **Templating**: Nunjucks with GOV.UK Frontend
+- **Asset bundling**: Webpack 5
+- **Hosting**: Containerised with Docker on: AWS ECS / Azure AKS
+
+## Project paths quick reference
+
+```
+src/
+├── config/           # Server and environment configuration
+├── plugins/          # Hapi plugins (auth, CSRF, CSP, views, session)
+├── routes/           # Route handlers — one file per route group
+├── services/         # Business logic — called by route handlers
+├── utils/            # Shared utilities (validation helpers, formatters)
+├── views/
+│   ├── layouts/      # Nunjucks base layouts (main.njk)
+│   ├── partials/     # Reusable template fragments
+│   ├── macros/       # GOV.UK component macros
+│   ├── errors/       # Error page templates (404, 500)
+│   └── pages/        # Page-level templates
+├── public/           # Static assets (CSS, images, compiled JS)
+└── __tests__/        # Test files mirroring src/ structure
+```
+
+## Naming conventions
+
+- **Directories and templates**: `kebab-case` (e.g. `submit-application.njk`)
+- **JavaScript files**: `camelCase` (e.g. `applicationService.js`)
+- **Route paths (URLs)**: lowercase with hyphens (e.g. `/submit-application`)
+- **Environment variables**: `UPPER_SNAKE_CASE` (e.g. `DATABASE_HOST`)
+
+## Tech stack and standards
+
+- Use Hapi for all HTTP servers — do not use Express
+- Use Nunjucks for server-side rendering — do not use React, Vue, or Angular
+- Use vanilla JavaScript with JSDoc for type annotations — do not use TypeScript without an approved exception
+- Use `const` by default, `let` only when reassignment is needed, never `var`
+- Use `async`/`await` — no callbacks or raw `.then()` chains
+- Lint with ESLint and format with Prettier
+- Pages must work without JavaScript enabled (progressive enhancement)
+
+## Architecture
+
+Keep controllers thin: validate input, call a service, render a view.
+
+```
+Route handler → validates input (joi) → calls service → h.view('pages/...', context)
+```
+
+## Validation
+
+- Use `joi` (standalone package) for request and payload validation
+- Do not use the deprecated `@hapi/joi`
+- Return errors inline next to the field and in an error summary at the top of the page
+
+## CSRF protection
+
+- All state-changing routes must have CSRF protection via `@hapi/crumb`
+- For API endpoints legitimately exempt (e.g. webhooks with HMAC auth), explicitly disable it:
+  ```javascript
+  options: { plugins: { crumb: false } }  // Exempt — uses HMAC signature verification
+  ```
+
+## Content Security Policy
+
+- Use `@hapi/blankie` for CSP headers
+- Do not add `unsafe-inline` or `unsafe-eval` to script sources
+- Do not allow third-party script sources unless explicitly approved
+- Set `frame-ancestors` to `'none'`
+- No inline scripts or `on*` event handlers in templates
+
+## Security headers
+
+Set these headers on all responses:
+
+| Header | Value |
+|--------|-------|
+| `X-Content-Type-Options` | `nosniff` |
+| `X-Frame-Options` | `DENY` |
+| `Referrer-Policy` | `no-referrer` |
+| `Strict-Transport-Security` | `max-age=31536000; includeSubDomains` |
+| `Cache-Control` | `no-store` (for pages with user data) |
+
+## Cookie settings
+
+All cookies must use:
+
+- `HttpOnly: true`
+- `Secure: true`
+- `SameSite: Lax`
+- Minimal scope and TTL — store only session state
+
+## Logging
+
+- Use Winston for structured JSON logging
+- Never log PII (names, addresses, emails, NI numbers, bank details, API keys)
+- Include correlation IDs for request tracing
+- Development: `debug` | Production: `error` only
+
+## Testing
+
+- Jest for unit and integration tests
+- Supertest for HTTP endpoint testing via `createServer()`
+- 90% coverage minimum — do not decrease from the SonarCloud baseline
+- Mock external dependencies
+- Every route must include tests for at minimum: happy path, validation failure, CSRF protection, and security headers
+
+## Allowed dependencies
+
+| Package | Purpose |
+|---------|---------|
+| `@hapi/hapi` | HTTP server |
+| `@hapi/boom` | Error responses |
+| `@hapi/crumb` | CSRF protection |
+| `@hapi/blankie` | CSP headers |
+| `@hapi/inert` | Static file serving |
+| `@hapi/vision` | Template rendering |
+| `@hapi/yar` | Session management |
+| `joi` | Schema validation |
+| `nunjucks` | Templating |
+| `winston` | Logging |
+| `mongodb` | Native MongoDB driver (do not use Mongoose) |
+
+**Discouraged:** `express`, `@hapi/joi` (deprecated), `mongoose`, `moment`, `lodash`, `request`, `jquery`
+
+## Branching
+
+- All work on branches, never directly on main (trunk-based development with short-lived feature branches)
+- Branch naming: `feature/`, `fix/`, `docs/`, `refactor/`
+- Conventional commits: `feat:`, `fix:`, `docs:`, `test:`, `chore:`
+
+## Accessibility
+
+- WCAG 2.2 Level AA — mandatory for all pages
+- Semantic HTML, keyboard navigation, visible focus indicators
+- GOV.UK Design System components and patterns
+- Error summaries at the top of the page, inline errors next to fields
+
+## How Copilot should respond
+
+- Follow the conventions already established in the codebase
+- Prefer modifying existing files over creating new ones
+- Provide complete, minimal diffs touching only necessary files
+- Keep changes minimal and focused on the request
+- Always include or update tests for changed behaviour — co-locate tests with the existing test layout
+- For any form or reusable UI pattern, propose or extend a Nunjucks macro using GOV.UK components
+- Keep solutions DRY: before adding new utilities, search for similar code in `src/utils/` or existing routes
+- Justify any security-sensitive deviation (e.g. disabling CSRF or loosening CSP) in code comments and default to the most restrictive safe option
+- If a request conflicts with these instructions, flag the conflict
+
+## Example prompts Copilot should act on
+
+- "Add a GET and POST route for a GOV.UK form using Nunjucks macros, CSRF via crumb, and Joi validation. Render errors per GDS."
+- "Create a Nunjucks macro for a GOV.UK text input with label, hint, and error message, then reuse it in a page."
+- "Add Jest + Supertest tests for route validation errors and security headers."
+````
+
+---
+
+## Adapting this example
+
+When copying this for your own service:
+
+1. Replace the project overview with your service's details
+2. Update the project paths to match your directory structure
+3. Edit the allowed dependencies table for your specific needs
+4. Add or remove sections based on your tech stack — remove Nunjucks sections if you are building an API-only service, for example
+5. If your project uses C#, see the [C# backend instructions]({{ "/tool-setup/github-copilot/instructions/csharp-backend" | relative_url }}) instead
+
+[Back to instructions index]({{ "/tool-setup/github-copilot/instructions" | relative_url }}) · [Back to GitHub Copilot setup guide]({{ "/tool-setup/github-copilot-setup" | relative_url }})

--- a/tool-setup/github-copilot/prompts/index.md
+++ b/tool-setup/github-copilot/prompts/index.md
@@ -1,0 +1,60 @@
+# Prompts — Examples for GitHub Copilot
+
+Prompts are reusable templates for common tasks. Unlike instructions (always active) or agents (personas), prompts are one-shot — run them when you need a specific output.
+
+## How prompts work
+
+Prompt files live in `.github/prompts/` and use the `.prompt.md` extension. When you open Copilot Chat, you can select a prompt from the prompt picker to run it.
+
+Prompts can include:
+- A description of the expected output
+- The file format and save location
+- Variables (placeholders) that the user fills in
+- References to instruction files for standards context
+
+## How to use these examples
+
+1. Copy the `.prompt.md` file into your repository's `.github/prompts/` directory
+2. Open Copilot Chat and select the prompt from the picker
+3. Fill in any variables when prompted
+4. Review the generated output before saving
+
+## Available examples
+
+| Prompt | Purpose | Output |
+|--------|---------|--------|
+| [Write ADR]({{ "/tool-setup/github-copilot/prompts/write-adr" | relative_url }}) | Generate architecture decision records | Markdown ADR document |
+| [Write Tests]({{ "/tool-setup/github-copilot/prompts/write-tests" | relative_url }}) | Generate test suites for existing code | Jest test file |
+| [Security Review]({{ "/tool-setup/github-copilot/prompts/security-review" | relative_url }}) | Review code against OWASP and Defra security standards | Review findings report |
+| [Scaffold Repo]({{ "/tool-setup/github-copilot/prompts/scaffold-repo" | relative_url }}) | Generate the full `.github/` Copilot config for a Defra project | Complete directory structure |
+
+## Writing your own prompts
+
+Follow this structure:
+
+```markdown
+---
+description: One-line summary of what this prompt produces
+---
+
+# Prompt Title
+
+[Clear description of what to generate]
+
+## Context
+[What the user needs to provide or select]
+
+## Output format
+[Expected structure, file type, save location]
+
+## Standards
+[Reference to instruction files or external standards]
+```
+
+**Tips:**
+- Start with a clear description of the expected output
+- Tell Copilot where to save the file
+- Reference instruction files for standards rather than restating rules
+- Keep prompts focused on one task
+
+[Back to GitHub Copilot setup guide]({{ "/tool-setup/github-copilot-setup" | relative_url }})

--- a/tool-setup/github-copilot/prompts/scaffold-repo.md
+++ b/tool-setup/github-copilot/prompts/scaffold-repo.md
@@ -1,0 +1,121 @@
+# Scaffold Repository Config Prompt — Example
+
+This is an example `.prompt.md` file for bootstrapping the full GitHub Copilot configuration in a Defra repository. Run it once when starting a new project or adding Copilot support to an existing one.
+
+## Example file contents
+
+The content below goes into your `.github/prompts/scaffold-repo.prompt.md` file:
+
+---
+
+````markdown
+---
+description: Generate the full .github/ Copilot configuration for a Defra project
+---
+
+# Scaffold Copilot Config
+
+Generate the complete `.github/` directory structure for this repository, including root instructions, scoped instructions, agents, and prompts. Tailor every file to the project details below.
+
+## Project details
+
+Provide these values (edit them before running this prompt):
+
+- **Service name**: [e.g. Waste exemptions service]
+- **Service description**: [e.g. Allows waste operators to register exemptions from environmental permits]
+- **Tech stack**: [Node.js + Hapi | .NET + ASP.NET Core Minimal API | both]
+- **Frontend**: [Nunjucks + GOV.UK Frontend | Razor Pages | API only (no frontend)]
+- **Database**: [PostgreSQL | MongoDB | DynamoDB | none]
+- **Hosting**: [AWS ECS | Azure AKS | Azure App Service | other]
+- **Auth method**: [Azure AD | Magic link | Basic session | none]
+- **Message broker**: [Azure Service Bus | AWS SQS | RabbitMQ | none]
+
+## Files to generate
+
+Create every file listed below. Skip sections that do not apply based on the tech stack.
+
+### 1. Root instructions — `.github/copilot-instructions.md`
+
+Include:
+- Project overview with service name, description, and tech stack from above
+- Project paths — match the actual directory layout of this repository
+- Naming conventions (kebab-case directories, camelCase JS files, PascalCase C# files)
+- Branching and version control (trunk-based, conventional commits, squash-and-merge)
+- Quality gates (ESLint + Prettier for JS, dotnet format for C#, SonarCloud quality gate, 90% coverage)
+- Allowed dependencies table — list the packages this project actually uses
+- Discouraged dependencies — Express, lodash, moment, jquery, @hapi/joi
+- Security rules — OWASP, no PII in logs, joi validation, parameterised queries
+- How Copilot should respond — follow existing patterns, minimal diffs, include tests
+
+### 2. Scoped instructions — `.github/instructions/`
+
+**For Node.js projects**, create `node-backend.instructions.md`:
+- `applyTo: "**/*.js,**/*.mjs"`
+- Hapi framework conventions, @hapi/boom, joi, @hapi/crumb, @hapi/blankie
+- Route handler → service → view pattern
+- CSRF, CSP, security headers, cookie settings
+- Winston logging, health endpoint, config module
+- Jest + Supertest testing
+
+**For .NET projects**, create `csharp-backend.instructions.md`:
+- `applyTo: "**/*.cs,**/*.csproj"`
+- Minimal API conventions, Serilog, FluentValidation
+- xUnit v3 + FluentAssertions + NSubstitute testing
+- Health endpoint, dependency injection, nullable reference types
+
+**For frontend projects**, create `frontend.instructions.md`:
+- `applyTo: "**/*.njk,**/*.html,**/*.css"`
+- GOV.UK Design System, macro-first, no inline styles
+- WCAG 2.2 AA, semantic HTML, error summary linking
+- Nunjucks directory structure, progressive enhancement
+
+### 3. Agents — `.github/agents/`
+
+Create `defra-app-developer.agent.md`:
+- Persona: senior Defra developer
+- Tech stack section matching the project details above
+- Full workflow with pre-commit checklist including SonarCloud quality gate
+- Coding standards, security, logging, accessibility, documentation, containers
+- Reference the tester agent for testing details
+
+Create `code-reviewer.agent.md`:
+- 9-category review checklist (PR hygiene, correctness, tests, security, performance, maintainability, architecture, documentation, accessibility)
+- Severity levels (blocking, recommended, nit)
+- SonarCloud quality gate and security hotspot checks
+
+Create `tester.agent.md`:
+- BDD testing approach with testing pyramid
+- Test naming conventions with examples
+- Minimum route test scenarios (happy path, validation, CSRF, auth, 404)
+- Security testing checklist
+- Coverage targets table (90% global, 95% business logic, 100% security)
+
+### 4. Prompts — `.github/prompts/`
+
+Create `write-adr.prompt.md`:
+- Standard ADR template (context, decision, consequences, alternatives)
+- Plain English, active voice, reference Defra standards
+
+Create `write-tests.prompt.md`:
+- Generate test suites following the project's test framework
+- Coverage targets, mocking strategy, BDD naming
+
+Create `security-review.prompt.md`:
+- OWASP-based security review
+- Defra-specific checks (PII, CSRF, CSP, secrets)
+
+## Rules
+
+- Use British English throughout (organisation, colour, licence, behaviour)
+- Follow GOV.UK style guide — plain English, sentences under 25 words, active voice
+- Do not include placeholder text like "[TODO]" — use the project details provided above
+- Every instruction must be actionable and imperative ("Use Hapi" not "Hapi should be used")
+- Include one example and one counterexample for key rules
+- Reference Defra software development standards where applicable
+- Keep each file under 200 lines
+- Do not duplicate rules — define each rule in one file and cross-reference from others
+````
+
+---
+
+[Back to prompts index]({{ "/tool-setup/github-copilot/prompts" | relative_url }}) · [Back to GitHub Copilot setup guide]({{ "/tool-setup/github-copilot-setup" | relative_url }})

--- a/tool-setup/github-copilot/prompts/security-review.md
+++ b/tool-setup/github-copilot/prompts/security-review.md
@@ -1,0 +1,87 @@
+# Security Review Prompt — Example
+
+This is an example `.prompt.md` file for reviewing code against security standards. Copy it into `.github/prompts/security-review.prompt.md` in your repository.
+
+## Example file contents
+
+The content below goes into your `.github/prompts/security-review.prompt.md` file:
+
+---
+
+````markdown
+---
+description: Review selected code against OWASP and Defra security standards
+---
+
+# Security Review
+
+Review the selected code for security vulnerabilities. Check against OWASP Secure Coding Practices and Defra security standards.
+
+## Review checklist
+
+Work through each category and report any findings:
+
+### 1. Input validation
+- All user input is validated (type, length, range, format)
+- Input is sanitised before use in queries, file paths, or HTML output
+- Validation happens server-side (client-side validation is not sufficient)
+
+### 2. Authentication and authorisation
+- Authentication checks are present on protected routes
+- Authorisation verifies the user has permission for the specific resource
+- Session tokens are generated securely and have appropriate expiry
+
+### 3. Data protection
+- No secrets, API keys, or tokens in source code
+- Secrets are loaded from environment variables or a secret manager
+- Sensitive data is encrypted in transit (TLS) and at rest
+- PII is not logged (names, addresses, emails, phone numbers, NI numbers, bank details)
+
+### 4. Injection prevention
+- SQL queries use parameterised statements or an ORM
+- No string concatenation in queries, commands, or file paths with user input
+- HTML output is escaped to prevent XSS
+- HTTP headers include security protections (CSP, X-Frame-Options, HSTS)
+
+### 5. Error handling
+- Error messages do not leak internal details (stack traces, SQL queries, file paths)
+- Errors are logged server-side with sufficient detail for debugging
+- The application fails securely — denied by default on error
+
+### 6. Dependencies
+- No known vulnerable dependencies (check `npm audit` or equivalent)
+- Dependencies are from trusted sources (npm registry, NuGet)
+- Lock file (`package-lock.json`) is committed and up to date
+
+### 7. Logging and monitoring
+- Security-relevant events are logged (authentication attempts, access failures, configuration changes)
+- Logs do not contain secrets or PII
+- Logs include correlation IDs for tracing
+
+## Output format
+
+For each finding, provide:
+
+| Field | Content |
+|-------|---------|
+| **Severity** | Critical / High / Medium / Low |
+| **Category** | Which checklist category |
+| **Location** | File and line reference |
+| **Description** | What the vulnerability is |
+| **Risk** | What could happen if exploited |
+| **Recommendation** | How to fix it with a code example |
+
+Summarise at the end: total findings by severity and the overall risk assessment.
+
+## References
+
+- [OWASP Secure Coding Practices](https://owasp.org/www-project-secure-coding-practices-quick-reference-guide/)
+- [OWASP Top 10](https://owasp.org/www-project-top-ten/)
+- [Defra security standards](https://github.com/DEFRA/software-development-standards/blob/main/docs/standards/security_standards.md)
+- [Defra logging standards](https://github.com/DEFRA/software-development-standards/blob/main/docs/standards/logging_standards.md)
+- [NCSC secure development principles](https://www.ncsc.gov.uk/collection/developers-collection)
+````
+
+---
+
+[Back to prompts index]({{ "/tool-setup/github-copilot/prompts" | relative_url }}) · [Back to GitHub Copilot setup guide]({{ "/tool-setup/github-copilot-setup" | relative_url }})

--- a/tool-setup/github-copilot/prompts/write-adr.md
+++ b/tool-setup/github-copilot/prompts/write-adr.md
@@ -1,0 +1,80 @@
+# Write ADR Prompt — Example
+
+This is an example `.prompt.md` file for generating Architecture Decision Records (ADRs). Copy it into `.github/prompts/write-adr.prompt.md` in your repository.
+
+## Example file contents
+
+The content below goes into your `.github/prompts/write-adr.prompt.md` file:
+
+---
+
+````markdown
+---
+description: Generate an Architecture Decision Record (ADR) from a design discussion
+---
+
+# Write ADR
+
+Generate an Architecture Decision Record for the design decision described below. Follow the standard ADR template.
+
+## Output format
+
+Save the file as `docs/ADRs/NNNN-title-in-kebab-case.md` where NNNN is the next sequence number.
+
+Use this template:
+
+```markdown
+# NNNN. Title
+
+**Date:** YYYY-MM-DD
+
+**Status:** Proposed | Accepted | Deprecated | Superseded by [NNNN]
+
+## Context
+
+What is the issue that we are seeing that motivates this decision or change?
+
+## Decision
+
+What is the change that we are proposing and/or doing?
+
+## Consequences
+
+What becomes easier or more difficult to do because of this change?
+
+### Positive
+- Benefit one
+- Benefit two
+
+### Negative
+- Trade-off one
+- Trade-off two
+
+### Risks
+- Risk one and its mitigation
+
+## Alternatives considered
+
+### Alternative A: [Name]
+- Description
+- Why it was not chosen
+
+### Alternative B: [Name]
+- Description
+- Why it was not chosen
+```
+
+## Rules
+
+- Write in plain English using active voice
+- Be specific about technologies, versions, and constraints
+- State the decision clearly in one sentence
+- List at least two alternatives that were considered
+- Include both positive and negative consequences — be honest about trade-offs
+- Reference Defra software development standards where the decision relates to an existing standard
+- If the decision conflicts with a Defra standard, explain why and note that an exception is needed
+````
+
+---
+
+[Back to prompts index]({{ "/tool-setup/github-copilot/prompts" | relative_url }}) · [Back to GitHub Copilot setup guide]({{ "/tool-setup/github-copilot-setup" | relative_url }})

--- a/tool-setup/github-copilot/prompts/write-tests.md
+++ b/tool-setup/github-copilot/prompts/write-tests.md
@@ -1,0 +1,79 @@
+# Write Tests Prompt — Example
+
+This is an example `.prompt.md` file for generating test suites. Copy it into `.github/prompts/write-tests.prompt.md` in your repository.
+
+## Example file contents
+
+The content below goes into your `.github/prompts/write-tests.prompt.md` file:
+
+---
+
+````markdown
+---
+description: Generate a test suite for the selected code
+---
+
+# Write Tests
+
+Generate a comprehensive test suite for the selected code. Follow Defra testing standards and quality targets.
+
+## What to test
+
+Analyse the selected code and generate tests covering:
+
+1. **Happy path** — the expected behaviour with valid inputs
+2. **Edge cases** — boundary values, empty inputs, minimum and maximum values
+3. **Error cases** — invalid inputs, missing dependencies, network failures
+4. **Security cases** — malicious input, injection attempts (where applicable)
+
+## Output format
+
+- Use Jest as the test framework
+- Save the test file alongside the source file with `.test.js` suffix
+  - Example: `src/services/application.js` → `src/services/application.test.js`
+- Use `describe` and `it` blocks with descriptive names
+
+## Test structure
+
+```javascript
+import { functionName } from './module-name.js'
+
+describe('functionName', () => {
+  describe('when given valid input', () => {
+    it('should return the expected result', () => {
+      // Arrange
+      const input = { /* valid data */ }
+
+      // Act
+      const result = functionName(input)
+
+      // Assert
+      expect(result).toEqual(expectedOutput)
+    })
+  })
+
+  describe('when given invalid input', () => {
+    it('should throw a descriptive error', () => {
+      expect(() => functionName(null)).toThrow('Input is required')
+    })
+  })
+})
+```
+
+## Rules
+
+- Mock external dependencies (databases, APIs, file system) — do not make real network calls
+- Test behaviour, not implementation details
+- Each test should be independent — no shared mutable state between tests
+- Use `beforeEach` for common setup, not `beforeAll` (unless expensive and read-only)
+- Do not use `test.only` or `describe.only` in committed code
+- Do not reduce existing test coverage
+- Target 90% coverage minimum for new code
+- Core business logic must reach 95% coverage
+- Error and security paths must reach 100% coverage
+- Do not include PII in test fixtures or assertions
+````
+
+---
+
+[Back to prompts index]({{ "/tool-setup/github-copilot/prompts" | relative_url }}) · [Back to GitHub Copilot setup guide]({{ "/tool-setup/github-copilot-setup" | relative_url }})

--- a/tool-setup/index.md
+++ b/tool-setup/index.md
@@ -1,0 +1,55 @@
+# Tool Setup Guidance
+
+This section provides practical setup guidance for configuring AI coding tools in Defra projects. Each guide includes example files you can copy directly into your repositories.
+
+## Why this matters
+
+AI tools work best when given clear, project-specific context. A well-configured AI coding assistant will:
+
+- Follow your team's coding standards and conventions automatically
+- Produce code that passes your quality gates first time
+- Understand your architecture and make consistent decisions
+- Save time on repetitive tasks like writing tests, ADRs, and documentation
+
+These setup guides implement the [four pillars](https://defra.github.io/defra-ai-sdlc/pages/getting-started/the-four-pillars){:target="_blank"} (opens in new tab) from the [Defra AI SDLC playbook](https://defra.github.io/defra-ai-sdlc/){:target="_blank"} (opens in new tab) — particularly **Rules and Instructions** and **Prompts** — with ready-to-use configuration files for each tool.
+
+## Available guides
+
+### GitHub Copilot
+
+Set up GitHub Copilot with agents, instructions, and reusable prompts tailored for Defra projects.
+
+[GitHub Copilot setup guide]({{ "/tool-setup/github-copilot-setup" | relative_url }})
+
+Includes ready-to-use examples for:
+- **Agents** — specialised AI personas (Defra App Developer, Code Reviewer, Tester)
+- **Instructions** — project-specific rules and standards (Node.js backend, frontend, root config)
+- **Prompts** — reusable prompt templates (ADRs, tests, security reviews)
+
+### Cursor
+
+Set up Cursor with rule files tailored for Defra projects.
+
+[Cursor setup guide]({{ "/tool-setup/cursor-setup" | relative_url }})
+
+Includes ready-to-use examples for:
+- **Node.js backend rules** — Hapi, vanilla JS, MongoDB, REST API patterns, Jest testing
+- **Node.js frontend rules** — GOV.UK Design System, Nunjucks, Playwright testing, accessibility
+- **Python backend rules** — FastAPI, pytest, MongoDB mocking patterns
+
+### Claude Code
+
+*Coming soon* — setup guidance for Claude Code with custom agents and instructions.
+
+### Using these examples with other AI tools
+
+The rules and standards encoded in the examples above work with any AI coding tool. See [Using these examples with other AI tools]({{ "/tool-setup/cross-tool-config" | relative_url }}) for how to adapt the configuration for Claude Code, Cursor, and Windsurf.
+
+## How to use the examples
+
+1. Browse the guide for your tool to understand the configuration structure
+2. Navigate to the example files that match your project's needs
+3. Copy the raw markdown content into the matching directory in your repository
+4. Edit the examples to fit your specific project context
+
+All examples follow [Defra software development standards](https://github.com/DEFRA/software-development-standards) and encode the key guardrails so your AI assistant produces compliant code from the start.


### PR DESCRIPTION
- Remove leading spaces from all Liquid template paths fixing %20 in every URL
- Expand Tool Setup nav with GitHub Copilot sub-pages (Agents, Instructions, Prompts)
- Add Cursor sub-nav (Node.js backend, Node.js frontend, Python backend)
- Add cross-tool config to nav